### PR TITLE
fix(config): Respect custom MODEL_PATH values

### DIFF
--- a/blackletter/config.py
+++ b/blackletter/config.py
@@ -13,9 +13,9 @@ class RedactionConfig:
 
     def __post_init__(self):
         """Resolve model path after initialization."""
-
-        root = Path(__file__).parent
-        self.MODEL_PATH: str = str(root / "models" / "best.pt")
+        if self.MODEL_PATH is None:
+            root = Path(__file__).parent
+            self.MODEL_PATH = str(root / "models" / "best.pt")
 
     # Image processing
     dpi: int = 200

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,7 +10,7 @@ def test_config_imports():
     config = RedactionConfig()
     assert config.dpi == 200
     assert config.confidence_threshold == 0.20
-    assert config.MODEL_PATH == "best.pt"
+    assert config.MODEL_PATH.endswith("models/best.pt")
 
 
 def test_core_imports():


### PR DESCRIPTION
__post_init__ was unconditionally overwriting MODEL_PATH, ignoring any user-provided value. 

Now only resolves to default when None.

Also fix test assertion to check path suffix rather than exact string, since the resolved absolute path is the intended behavior.