### PR TITLE
perf(analyze): eliminate temp PNG files for OCR crops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Coming up
+
+The following changes are not yet released, but are code complete:
+
+- Add lazy per-page word cache for `_tighten_to_text`, `_text_bottom`, and `_text_x_bounds`, replacing repeated `fitz_page.get_text()` calls (#35)
+- Replace two `document.by_label()` calls with a single pass over page detections in `_pair_opinions()`, reducing from 3 sorts to 1 (#36)
+- Replace per-opinion detection scanning with a single pre-sorted list and bisect slicing in `_build_full_redacted` (#37)
+- Eliminate temp PNG file writes during OCR crop processing, reducing I/O overhead and preventing leaked files in `/tmp` on crashes (#38)
+
 ## Current
 
 0.0.8 (2026-04-01)

--- a/blackletter/analyze.py
+++ b/blackletter/analyze.py
@@ -85,7 +85,8 @@ def _scan_crop(
         return hits, near_misses
     import numpy as np
 
-    result = ocr.predict(np.array(pil_crop))
+    # paddlex assumes numpy arrays are BGR; PIL gives RGB, so swap channels.
+    result = ocr.predict(np.array(pil_crop)[:, :, ::-1])
     if not result or not result[0]:
         return hits, near_misses
     r = result[0]
@@ -153,13 +154,14 @@ def _ocr_crop_multi(
                 return False
         return typ == "single"
 
-    # 1) PaddleOCR -- pass numpy array directly, no temp file needed
+    # 1) PaddleOCR -- pass numpy array directly, no temp file needed.
+    # paddlex assumes numpy arrays are BGR; PIL gives RGB, so swap channels.
     if ocr is None:
         result = None
     else:
         import numpy as np
 
-        result = ocr.predict(np.array(pil_crop))
+        result = ocr.predict(np.array(pil_crop)[:, :, ::-1])
     if result and result[0]:
         r = result[0]
         texts = r.get("rec_texts", []) if isinstance(r, dict) else getattr(r, "rec_texts", [])

--- a/blackletter/analyze.py
+++ b/blackletter/analyze.py
@@ -44,23 +44,29 @@ def _classify_text(stripped: str) -> tuple[str, str] | None:
 
 def _scan_crop(
     ocr,
-    img_bytes: bytes,
+    pil_crop: Image.Image,
     zone_name: str,
     page_idx: int,
     x_offset: int = 0,
     y_offset: int = 0,
 ) -> tuple[list, list]:
-    tmp_path = f"/tmp/pn_{os.getpid()}_{page_idx}_{zone_name}.png"
-    with open(tmp_path, "wb") as f:
-        f.write(img_bytes)
+    """Run OCR on a cropped PIL image and classify detected text.
+
+    :param ocr: PaddleOCR instance (or None to fall back to Tesseract).
+    :param pil_crop: Cropped PIL image to scan.
+    :param zone_name: Label for the crop zone (e.g. ``"corner-L"``).
+    :param page_idx: Zero-based page index (used for logging).
+    :param x_offset: Horizontal pixel offset to add to polygon coordinates.
+    :param y_offset: Vertical pixel offset to add to polygon coordinates.
+    :returns: ``(hits, near_misses)`` where each is a list of result dicts.
+    :rtype: tuple[list, list]
+    """
     hits, near_misses = [], []
     if ocr is None:
         try:
             import pytesseract
-            from PIL import Image as _I
 
-            pil_img = _I.open(tmp_path)
-            tess_text = pytesseract.image_to_string(pil_img, config="--psm 6").strip()
+            tess_text = pytesseract.image_to_string(pil_crop, config="--psm 6").strip()
             for line in tess_text.splitlines():
                 classified = _classify_text(line.strip())
                 if classified:
@@ -77,7 +83,9 @@ def _scan_crop(
         except Exception:
             pass
         return hits, near_misses
-    result = ocr.predict(tmp_path)
+    import numpy as np
+
+    result = ocr.predict(np.array(pil_crop))
     if not result or not result[0]:
         return hits, near_misses
     r = result[0]
@@ -110,12 +118,28 @@ def _ocr_crop_multi(
     ocr,
     glm_processor,
     glm_model,
-    pil_crop,
+    pil_crop: Image.Image,
     zone_name: str,
     page_idx: int,
     exp_start: int | None = None,
     exp_end: int | None = None,
 ) -> dict | None:
+    """Run multi-engine OCR on a crop, returning the first valid result.
+
+    Tries PaddleOCR first, then Tesseract, then GLM-OCR (rare fallback).
+
+    :param ocr: PaddleOCR instance, or None to skip.
+    :param glm_processor: Pre-loaded GLM AutoProcessor, or None.
+    :param glm_model: Pre-loaded GLM model, or None.
+    :param pil_crop: Cropped PIL image to run OCR on.
+    :param zone_name: Label for the crop zone (e.g. ``"yolo-pn"``).
+    :param page_idx: Zero-based page index (used for logging and caching).
+    :param exp_start: Expected first page number, for range validation.
+    :param exp_end: Expected last page number, for range validation.
+    :returns: Result dict with keys ``text``, ``score``, ``zone``, ``type``,
+        ``ocr``, or None if no valid page number was found.
+    :rtype: dict | None
+    """
     margin = 20
 
     def is_valid(text, typ):
@@ -129,14 +153,13 @@ def _ocr_crop_multi(
                 return False
         return typ == "single"
 
-    tmp_path = f"/tmp/pn_{os.getpid()}_{page_idx}_{zone_name}.png"
-    pil_crop.save(tmp_path)
-
-    # 1) PaddleOCR
+    # 1) PaddleOCR -- pass numpy array directly, no temp file needed
     if ocr is None:
         result = None
     else:
-        result = ocr.predict(tmp_path)
+        import numpy as np
+
+        result = ocr.predict(np.array(pil_crop))
     if result and result[0]:
         r = result[0]
         texts = r.get("rec_texts", []) if isinstance(r, dict) else getattr(r, "rec_texts", [])
@@ -193,7 +216,10 @@ def _ocr_crop_multi(
         except Exception:
             pass
     if glm_processor is not None and glm_model is not None:
+        # GLM needs a file path; write a temp file only for this rare fallback.
+        tmp_path = f"/tmp/pn_{os.getpid()}_{page_idx}_{zone_name}.png"
         try:
+            pil_crop.save(tmp_path)
             messages = [
                 {
                     "role": "user",
@@ -232,6 +258,11 @@ def _ocr_crop_multi(
                         }
         except Exception:
             pass
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     return None
 
@@ -332,8 +363,6 @@ def _process_page(args: tuple) -> dict:
         _process_page._pdf = _fitz.open(pdf_path)
         _process_page._pdf_path = pdf_path
 
-    import io
-
     ocr = _process_page._ocr
     yolo = _process_page._yolo
     glm_proc = _process_page._glm_processor
@@ -344,11 +373,6 @@ def _process_page(args: tuple) -> dict:
     pix = page.get_pixmap(dpi=200)
     img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
     img_w, img_h = img.size
-
-    def img_to_bytes(pil_img):
-        buf = io.BytesIO()
-        pil_img.save(buf, format="PNG")
-        return buf.getvalue()
 
     page_num = None
 
@@ -437,13 +461,13 @@ def _process_page(args: tuple) -> dict:
             (img.crop((0, 0, half_w, crop_h)), "corner-L", 0),
             (img.crop((half_w, 0, img_w, crop_h)), "corner-R", half_w),
         ]:
-            hits, _ = _scan_crop(ocr, img_to_bytes(crop), cname, page_idx, x_offset=x_off)
+            hits, _ = _scan_crop(ocr, crop, cname, page_idx, x_offset=x_off)
             candidates.extend(hits)
         corner_result = _pick_best(candidates, img_w, img_h, exp_start, exp_end)
 
         if not corner_result or corner_result["score"] < MIN_SCORE:
             top_crop = img.crop((0, 0, img_w, crop_h))
-            hits, _ = _scan_crop(ocr, img_to_bytes(top_crop), "top", page_idx)
+            hits, _ = _scan_crop(ocr, top_crop, "top", page_idx)
             candidates.extend(hits)
             corner_result = _pick_best(candidates, img_w, img_h, exp_start, exp_end)
 


### PR DESCRIPTION
Eliminates temporary PNG file writes during OCR crop processing. Previously, every crop was encoded to PNG bytes, written to /tmp, and read back by PaddleOCR. Now crops are passed as in-memory numpy arrays, avoiding disk I/O entirely (except for the GLM-OCR fallback, which now cleans up after itself).    

the old code never cleaned up temp files, so a crash or killed process would leak files in /tmp. This also reduces syscall overhead. On a 1,359-page document (4,077 crops), the I/O layer drops from ~11.4s to ~0.5s (22x), saving roughly 2.7ms per crop. In practice this is a small fraction of total processing time since OCR inference dominates, but it adds up on large volumes.                              

These are some test results to see the time reduction by avoiding disk I/O:


```
Pages:  95
Rendering crops...
Crops:  285 (95 pages x 3 crops/page)

Running old (temp file)...
  Round 1: 1.710s  (285 crops)
  Round 2: 1.535s  (285 crops)
  Round 3: 1.581s  (285 crops)
Running new (in-memory)...
  Round 1: 0.060s  (285 crops)
  Round 2: 0.054s  (285 crops)
  Round 3: 0.057s  (285 crops)

Old (temp file):  1.609s avg  (best 1.535s)  [5.6ms/crop]
New (in-memory):  0.057s avg  (best 0.054s)  [0.2ms/crop]
Saved:            1.552s  (28.23x)
Per-crop saving:  5.4ms
```

```
Pages:  1359
Rendering crops...
Crops:  4077 (1359 pages x 3 crops/page)

Running old (temp file)...
  Round 1: 11.583s  (4077 crops)
  Round 2: 11.566s  (4077 crops)
  Round 3: 11.110s  (4077 crops)
Running new (in-memory)...
  Round 1: 0.484s  (4077 crops)
  Round 2: 0.489s  (4077 crops)
  Round 3: 0.546s  (4077 crops)

Old (temp file):  11.419s avg  (best 11.110s)  [2.8ms/crop]
New (in-memory):  0.506s avg  (best 0.484s)  [0.1ms/crop]
Saved:            10.913s  (22.56x)
Per-crop saving:  2.7ms
```

I used this script to test the I/O: 
[bench_crop_io.py](https://github.com/user-attachments/files/26728266/bench_crop_io.py)

