### PR TITLE
docs: add rST docstrings, type hints, and cleanup across core modules 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## Coming up
+
+The following changes are not yet released, but are code complete:
+
+- Add rST docstrings (`:param:` / `:returns:`) across all public and internal functions in `api.py`, `margins.py`, `models.py`, `analyze.py`, `scanner.py`, and `validate.py`
+- Add `Callable` type hints for `progress_callback` parameters in `api.py`, `analyze.py`, `scanner.py`, and `validate.py`
+- Fix resource leak in `api.ocr()` where `fitz.open()` was never closed
+- Remove dead `list[dict]` type from `api.build_redacted()` rects parameter
+- Fix stale module-level usage examples in `api.py`
+- Remove unnecessary import aliases (`_re`, `_Counter`, `_fitz`, `_I`) across `api.py` and `analyze.py`
+- Remove em dashes from comments and strings project-wide
+
 ## Current
 
 0.0.8 (2026-04-01)

--- a/blackletter/analyze.py
+++ b/blackletter/analyze.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
 
@@ -22,11 +23,13 @@ RANGE_RE = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
 
 
 def _page_num_base(text: str) -> int | None:
+    """Extract the leading integer from a string, or return ``None``."""
     m = re.match(r"^(\d+)", str(text))
     return int(m.group(1)) if m else None
 
 
 def _classify_text(stripped: str) -> tuple[str, str] | None:
+    """Classify text as a page number (``"single"`` or ``"range"``), or ``None``."""
     if RANGE_RE.match(stripped):
         return stripped, "range"
     if stripped.isdigit() and len(stripped) <= 4:
@@ -50,6 +53,17 @@ def _scan_crop(
     x_offset: int = 0,
     y_offset: int = 0,
 ) -> tuple[list, list]:
+    """OCR a cropped image region and extract page number candidates.
+
+    :param ocr: PaddleOCR instance, or ``None`` to fall back to
+        Tesseract.
+    :param img_bytes: PNG image bytes of the crop.
+    :param zone_name: Label for the crop region (e.g. ``"corner-L"``).
+    :param page_idx: Zero-based page index (for temp file naming).
+    :param x_offset: Horizontal offset to add to polygon coordinates.
+    :param y_offset: Vertical offset to add to polygon coordinates.
+    :returns: Tuple of (hits, near_misses) lists.
+    """
     tmp_path = f"/tmp/pn_{os.getpid()}_{page_idx}_{zone_name}.png"
     with open(tmp_path, "wb") as f:
         f.write(img_bytes)
@@ -57,9 +71,8 @@ def _scan_crop(
     if ocr is None:
         try:
             import pytesseract
-            from PIL import Image as _I
 
-            pil_img = _I.open(tmp_path)
+            pil_img = Image.open(tmp_path)
             tess_text = pytesseract.image_to_string(pil_img, config="--psm 6").strip()
             for line in tess_text.splitlines():
                 classified = _classify_text(line.strip())
@@ -116,6 +129,19 @@ def _ocr_crop_multi(
     exp_start: int | None = None,
     exp_end: int | None = None,
 ) -> dict | None:
+    """Try multiple OCR backends (PaddleOCR, Tesseract, GLM) on a crop.
+
+    :param ocr: PaddleOCR instance, or ``None``.
+    :param glm_processor: GLM-OCR processor, or ``None`` to lazy-load.
+    :param glm_model: GLM-OCR model, or ``None`` to lazy-load.
+    :param pil_crop: PIL Image of the cropped region.
+    :param zone_name: Label for the crop region.
+    :param page_idx: Zero-based page index.
+    :param exp_start: Expected first page number for validation.
+    :param exp_end: Expected last page number for validation.
+    :returns: Dict with ``text``, ``score``, ``zone``, ``type``, and
+        ``ocr`` keys, or ``None`` if no valid reading found.
+    """
     margin = 20
 
     def is_valid(text, typ):
@@ -174,7 +200,7 @@ def _ocr_crop_multi(
     except Exception:
         pass
 
-    # 3) GLM-OCR — lazy-load only when paddle + tesseract both fail
+    # 3) GLM-OCR, lazy-load only when paddle + tesseract both fail
     if glm_processor is None and glm_model is None:
         try:
             import torch
@@ -243,6 +269,18 @@ def _pick_best(
     exp_start: int | None = None,
     exp_end: int | None = None,
 ) -> dict | None:
+    """Select the best page number candidate from OCR results.
+
+    Filters by position (top corners) and expected range, then picks
+    the highest-score match.
+
+    :param candidates: List of candidate dicts from OCR scanning.
+    :param img_w: Image width in pixels.
+    :param img_h: Image height in pixels.
+    :param exp_start: Expected first page number for range filtering.
+    :param exp_end: Expected last page number for range filtering.
+    :returns: Best candidate dict, or ``None``.
+    """
     if not candidates:
         return None
 
@@ -287,7 +325,17 @@ def _pick_best(
 
 
 def _process_page(args: tuple) -> dict:
-    """Process a single page. Runs in a worker process."""
+    """Process a single page for page number detection.
+
+    Runs in a worker process. Uses YOLO to locate page number regions,
+    then OCR to read them.
+
+    :param args: Tuple of (page_idx, pdf_path, exp_start, exp_end,
+        model_path).
+    :returns: Dict with ``pdf_page``, ``detected``, ``zone``, ``type``,
+        ``score``, ``ocr``, ``detections``, ``img_width``, and
+        ``img_height``.
+    """
     page_idx, pdf_path, exp_start, exp_end, model_path = args
 
     if not hasattr(_process_page, "_ocr"):
@@ -320,16 +368,16 @@ def _process_page(args: tuple) -> dict:
             model_path = Path(downloaded)
         _process_page._yolo = YOLO(str(model_path))
     if not hasattr(_process_page, "_glm"):
-        # Lazy-load GLM-OCR: don't load the model upfront — only when needed
+        # Lazy-load GLM-OCR: don't load the model upfront, only when needed
         _process_page._glm_processor = None
         _process_page._glm_model = None
         _process_page._glm = True
-    import fitz as _fitz
+    import fitz
 
     if not hasattr(_process_page, "_pdf") or getattr(_process_page, "_pdf_path", None) != pdf_path:
         if hasattr(_process_page, "_pdf"):
             _process_page._pdf.close()
-        _process_page._pdf = _fitz.open(pdf_path)
+        _process_page._pdf = fitz.open(pdf_path)
         _process_page._pdf_path = pdf_path
 
     import io
@@ -391,7 +439,7 @@ def _process_page(args: tuple) -> dict:
         if yolo_result:
             break
 
-    # 1b) YOLO header — crop sides
+    # 1b) YOLO header, crop sides
     if not yolo_result and best_header:
         hx1, hy1, hx2, hy2, _ = best_header
         pad = 10
@@ -488,7 +536,7 @@ def analyze_pdf(
     max_pages: int = 9999,
     num_workers: int | None = None,
     model: str | Path | None = None,
-    progress_callback=None,
+    progress_callback: Callable[[int, int, str], None] | None = None,
 ) -> dict:
     """Analyze a PDF's page number sequence for QA/verification.
 
@@ -496,21 +544,22 @@ def analyze_pdf(
     then checks the sequence for gaps, duplicates, and coverage against
     an expected range.
 
-    Args:
-        pdf_path: Path to the PDF to analyze.
-        exp_start: Expected first page number (optional; inferred from filename if omitted).
-        exp_end: Expected last page number (optional).
-        max_pages: Maximum number of pages to process.
-        num_workers: Number of parallel workers (default: min(4, cpu_count)).
-        model: Path to YOLO model. Defaults to blackletter's bundled analyze.pt.
-        progress_callback: Optional callable(current, total, message) called after each page.
-
-    Returns:
-        Dict with keys:
-            total_pages, results, seq_issues, duplicates, seen_nums,
-            all_nums, missing_pages, ranges_found, not_detected
+    :param pdf_path: Path to the PDF to analyze.
+    :param exp_start: Expected first page number (inferred from filename
+        if omitted).
+    :param exp_end: Expected last page number.
+    :param max_pages: Maximum number of pages to process.
+    :param num_workers: Number of parallel workers (default:
+        min(4, cpu_count)).
+    :param model: Path to YOLO model. Defaults to blackletter's bundled
+        large.pt.
+    :param progress_callback: Optional callable(current, total, message)
+        called after each page.
+    :returns: Dict with keys ``total_pages``, ``results``,
+        ``seq_issues``, ``duplicates``, ``seen_nums``, ``all_nums``,
+        ``missing_pages``, ``ranges_found``, and ``not_detected``.
     """
-    import fitz as _fitz
+    import fitz
 
     pdf_path = str(pdf_path)
     if model is None:
@@ -537,7 +586,7 @@ def analyze_pdf(
     if num_workers is None:
         num_workers = min(4, cpu_count())
 
-    pdf = _fitz.open(pdf_path)
+    pdf = fitz.open(pdf_path)
     total = min(max_pages, len(pdf))
     pdf.close()
 

--- a/blackletter/analyze.py
+++ b/blackletter/analyze.py
@@ -22,12 +22,6 @@ PAGE_NUMBER_CLASS = 8
 RANGE_RE = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
 
 
-def _page_num_base(text: str) -> int | None:
-    """Extract the leading integer from a string, or return ``None``."""
-    m = re.match(r"^(\d+)", str(text))
-    return int(m.group(1)) if m else None
-
-
 def _classify_text(stripped: str) -> tuple[str, str] | None:
     """Classify text as a page number (``"single"`` or ``"range"``), or ``None``."""
     if RANGE_RE.match(stripped):

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -10,15 +10,16 @@ Usage:
     ocr_pdf = ocr(bitonal_pdf, output_dir)
     detections = detect(bitonal_pdf, output_dir, models=["medium", "large"])
     opinions = pair(detections, ocr_pdf, reporter="a3d", volume="333", first_page=1)
-    rects = compute_rects(opinions, detections, ocr_pdf)
-    redacted_pdf = build_redacted(ocr_pdf, rects, output_dir)
-    opinion_files = split_opinions(ocr_pdf, opinions, rects, output_dir)
+    rects = compute_rects(ocr_pdf, output_dir)
+    redacted_pdf = build_redacted(ocr_pdf, output_dir)
+    opinion_files = split_opinions(ocr_pdf, output_dir, opinions=opinions)
 """
 
 from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import fitz
@@ -29,14 +30,17 @@ def bitonal(
     output_dir: str | Path,
     dpi: int = 200,
     threshold: int = 160,
-    progress_callback=None,
+    progress_callback: Callable[[int, int, str], None] | None = None,
 ) -> Path:
     """Convert a PDF to bitonal (CCITT G4 TIFF images).
 
-    Args:
-        progress_callback: Optional callable(current, total, message)
-
-    Returns path to the bitonal PDF.
+    :param pdf_path: Path to the source PDF.
+    :param output_dir: Directory to write bitonal.pdf into.
+    :param dpi: Rendering resolution for rasterisation.
+    :param threshold: Grayscale threshold (0-255) for binarisation.
+    :param progress_callback: Optional callable(current, total, message)
+        invoked during processing.
+    :returns: Path to the bitonal PDF.
     """
     import io
     import numpy as np
@@ -82,7 +86,13 @@ def ocr(
 ) -> Path:
     """OCR a PDF (add text layer via ocrmypdf/Tesseract).
 
-    Returns path to the OCR'd PDF.
+    :param pdf_path: Path to the source PDF.
+    :param output_dir: Directory to write the OCR'd PDF into.
+    :param reporter: Reporter abbreviation for the output filename.
+    :param volume: Volume number for the output filename.
+    :param first_page: First page number (used to build the output filename).
+    :param language: Tesseract language code.
+    :returns: Path to the OCR'd PDF.
     """
     import logging
 
@@ -90,7 +100,8 @@ def ocr(
     output_dir = Path(output_dir)
 
     # Build scan name
-    total_pages = fitz.open(str(pdf_path)).page_count
+    with fitz.open(str(pdf_path)) as src:
+        total_pages = src.page_count
     last_page = first_page + total_pages - 1
     parts = [p for p in [reporter, str(volume), str(first_page), str(last_page)] if p]
     scan_name = ".".join(parts) if parts else pdf_path.stem
@@ -128,7 +139,13 @@ def detect(
 ) -> list[dict]:
     """Run YOLO detection on all pages with one or more models.
 
-    Returns merged detection list. Also saves detections.json.
+    :param pdf_path: Path to the bitonal PDF.
+    :param output_dir: Directory to write detections.json into.
+    :param models: Model size names to run (e.g. ``["medium", "large"]``).
+        Defaults to all three: small, medium, large.
+    :param confidence: Minimum confidence threshold for detections.
+    :returns: Merged detection list. Also saves detections.json to
+        *output_dir*.
     """
     from PIL import Image
     from ultralytics import YOLO
@@ -211,7 +228,12 @@ def detect(
         return (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
 
     def _iou(a, b):
-        """Intersection over union of two [x0, y0, x1, y1] boxes."""
+        """Compute intersection-over-union of two ``[x0, y0, x1, y1]`` boxes.
+
+        :param a: First bounding box.
+        :param b: Second bounding box.
+        :returns: IoU value in ``[0.0, 1.0]``.
+        """
         ix0 = max(a[0], b[0])
         iy0 = max(a[1], b[1])
         ix1 = min(a[2], b[2])
@@ -223,7 +245,12 @@ def detect(
         return inter / union if union > 0 else 0.0
 
     def _contains(outer, inner):
-        """True if outer bbox fully contains inner bbox."""
+        """Check whether *outer* bbox fully contains *inner* bbox.
+
+        :param outer: Outer ``[x0, y0, x1, y1]`` bounding box.
+        :param inner: Inner ``[x0, y0, x1, y1]`` bounding box.
+        :returns: ``True`` if *outer* contains *inner*.
+        """
         return (
             outer[0] <= inner[0]
             and outer[1] <= inner[1]
@@ -281,9 +308,16 @@ def pair(
     first_page: int = 1,
     excluded: set | None = None,
 ) -> list[dict]:
-    """Pair opinions from detections. Returns opinions list. Saves opinions.json.
+    """Pair opinions from detections.
 
-    Can accept detections as a list or path to detections.json.
+    :param detections: Detection list or path to detections.json.
+    :param pdf_path: Path to the OCR'd PDF.
+    :param reporter: Reporter abbreviation (e.g. ``"a3d"``).
+    :param volume: Volume number (e.g. ``"333"``).
+    :param first_page: First page number of the volume.
+    :param excluded: Set of page indices to exclude from pairing.
+    :returns: List of opinion dicts with page ranges, bboxes, and
+        outside_rects.
     """
     from blackletter.models import BBox, Detection as BLDetection, Document, Label, Page
     from blackletter.scanner import _pair_opinions, _outside_opinion_rects
@@ -434,10 +468,6 @@ def pair(
 
     src_pdf.close()
 
-    # # Save
-    # output_dir = pdf_path.parent
-    # (output_dir / "opinions.json").write_text(json.dumps(opinions_data))
-
     return opinions_data
 
 
@@ -448,9 +478,17 @@ def compute_rects(
     approved: set | None = None,
     skip_doctr: bool = False,
 ) -> list[dict]:
-    """Compute redaction rects from detections + opinions. Saves redaction_rects.json.
+    """Compute redaction rects from detections + opinions.
 
-    Reads detections.json and opinions.json from output_dir.
+    Reads detections.json from *output_dir*, pairs opinions, and writes
+    redaction_rects.json back into *output_dir*.
+
+    :param pdf_path: Path to the OCR'd PDF.
+    :param output_dir: Directory containing detections.json.
+    :param excluded: Set of page indices to exclude from pairing.
+    :param approved: Set of page indices pre-approved for redaction.
+    :param skip_doctr: Unused, kept for backwards compatibility.
+    :returns: List of redaction rect dicts.
     """
     from blackletter.tasks import pair_and_compute_rects as _pair_compute
 
@@ -478,11 +516,16 @@ def compute_rects(
 def build_redacted(
     pdf_path: str | Path,
     output_dir: str | Path,
-    rects: list[dict] | str | Path | None = None,
+    rects: str | Path | None = None,
 ) -> Path:
     """Build the full redacted PDF from precomputed rects.
 
-    Returns path to the redacted PDF.
+    :param pdf_path: Path to the OCR'd PDF.
+    :param output_dir: Directory containing detections.json and where the
+        redacted PDF will be written.
+    :param rects: Path to a redaction_rects.json file. If ``None``, uses
+        ``output_dir / "redaction_rects.json"``.
+    :returns: Path to the redacted PDF.
     """
     from blackletter.process import _build_redacted_from_rects
     from blackletter.models import Document, Page
@@ -491,10 +534,7 @@ def build_redacted(
     output_dir = Path(output_dir)
 
     # Load rects
-    rects_path = output_dir / "redaction_rects.json"
-    if rects is not None:
-        if isinstance(rects, (str, Path)):
-            rects_path = Path(rects)
+    rects_path = Path(rects) if rects is not None else output_dir / "redaction_rects.json"
 
     # Build minimal Document for the function
     src_pdf = fitz.open(str(pdf_path))
@@ -549,10 +589,15 @@ def split_opinions(
     """Split the redacted PDF into individual opinion PDFs.
 
     Creates redacted/, unredacted/, and masked/ subdirectories.
-    Returns dict with counts.
 
-    opinions: precomputed opinions list (from api.pair()). If omitted,
-              falls back to reading opinions.json from output_dir.
+    :param pdf_path: Path to the OCR'd (unredacted) PDF.
+    :param output_dir: Directory containing the redacted PDF and
+        opinions.json. Output subdirectories are created here.
+    :param unredacted: Whether to also generate unredacted opinion PDFs.
+    :param opinions: Precomputed opinions list (from :func:`pair`). If
+        ``None``, reads opinions.json from *output_dir*.
+    :returns: Dict with ``redacted``, ``unredacted``, and ``masked``
+        counts.
     """
     from blackletter.process import _split_from_redacted, _build_masked_opinions
 
@@ -608,26 +653,29 @@ def generate(
     reporter: str = "",
     volume: str = "",
     unredacted: bool = False,
-    progress_callback=None,
+    progress_callback: Callable[[int, int, str], None] | None = None,
 ) -> dict:
-    """Generate all output PDFs from a source PDF and a single redactions.json.
+    """Generate all output PDFs from a source PDF and a redactions payload.
 
-    redactions.json contains:
-      - "opinions": list of opinion dicts with outside_rects, page ranges, filenames
-      - "pages": dict of page_index → list of rects (margins + redaction rects, all PDF points)
+    The *redactions* payload (file or dict) contains:
 
-    Builds in one pass per page — no layering.
+    - ``"opinions"``: list of opinion dicts with outside_rects, page
+      ranges, and filenames.
+    - ``"pages"``: dict mapping page_index to a list of rects (margins
+      + redaction rects, all in PDF points).
 
-    Args:
-        pdf_path: Path to the source (OCR'd) PDF.
-        redactions: Path to redactions.json, or the parsed dict.
-        output_dir: Base output directory.
-        reporter: Reporter abbreviation for filenames (e.g. "a3d").
-        volume: Volume number for filenames (e.g. "214").
-        unredacted: Also generate unredacted opinion PDFs.
-        progress_callback: Optional callable(current, total, message).
+    Builds in one pass per page (no layering).
 
-    Returns dict with keys: redacted_dir, masked_dir, full_redacted, opinion_count.
+    :param pdf_path: Path to the source (OCR'd) PDF.
+    :param redactions: Path to redactions.json, or the parsed dict.
+    :param output_dir: Base output directory.
+    :param reporter: Reporter abbreviation for filenames (e.g.
+        ``"a3d"``).
+    :param volume: Volume number for filenames (e.g. ``"214"``).
+    :param unredacted: Also generate unredacted opinion PDFs.
+    :param progress_callback: Optional callable(current, total, message).
+    :returns: Dict with keys ``redacted_dir``, ``masked_dir``,
+        ``full_redacted``, and ``opinion_count``.
     """
     import re as _re
 
@@ -654,7 +702,12 @@ def generate(
         prefix += f"{volume}."
 
     def _opinion_filename(op):
-        """Build filename from opinion page numbers."""
+        """Build filename from opinion page numbers.
+
+        :param op: Opinion dict with ``first_page_number`` and
+            ``last_page_number`` keys.
+        :returns: Filename string (e.g. ``"a3d.333.0001-0010.pdf"``).
+        """
         first = op.get("first_page_number")
         last = op.get("last_page_number")
         if first is not None and last is not None:
@@ -681,11 +734,15 @@ def generate(
     def _apply_page(fitz_page, src_idx, opinion, mode):
         """Apply all rects for one page in one pass.
 
-        mode: 'full'     — all rects as specified, no outside-opinion whiteout
-              'redacted' — all rects as specified + outside-opinion whiteout
-              'masked'   — WHITE_IN_MASKED → white + outside-opinion whiteout
+        :param fitz_page: The ``fitz.Page`` to apply redactions to.
+        :param src_idx: Source page index in the original PDF.
+        :param opinion: Opinion dict (or ``None`` for full-redacted mode).
+        :param mode: One of ``"full"`` (all rects, no outside-opinion
+            whiteout), ``"redacted"`` (all rects + outside-opinion
+            whiteout), or ``"masked"`` (WHITE_IN_MASKED labels become
+            white + outside-opinion whiteout).
         """
-        # Page rects (margins + redactions) — all PDF points
+        # Page rects (margins + redactions), all PDF points
         for r in pages_rects.get(str(src_idx), []):
             rect = fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
             if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
@@ -804,7 +861,7 @@ def generate(
 
     for group in groups:
         if len(group) == 1:
-            # Single opinion (single-page or multi-page) — build normally
+            # Single opinion (single-page or multi-page), build normally
             op = opinions[group[0]]
             start_idx = op["caption_page"]
             end_idx = op["end_page"]
@@ -817,7 +874,7 @@ def generate(
             out.save(str(masked_dir / filename), garbage=4, deflate=True)
             out.close()
         else:
-            # Multiple same-page opinions — consolidate into one PDF
+            # Multiple same-page opinions, consolidate into one PDF
             # Only white out areas that ALL opinions consider "outside"
             first_op = opinions[group[0]]
             src_page_idx = first_op["caption_page"]
@@ -894,9 +951,14 @@ def margins(
     pdf_path: str | Path,
     output_dir: str | Path,
 ) -> list[dict]:
-    """Compute margin rects. Saves margin_rects.json.
+    """Compute margin rects and save margin_rects.json.
 
-    Returns the margin rects data.
+    Skips computation if margin_rects.json already exists in
+    *output_dir*.
+
+    :param pdf_path: Path to the source PDF.
+    :param output_dir: Directory to write margin_rects.json into.
+    :returns: List of margin rect dicts.
     """
     from blackletter.margins import compute_margin_rects
 

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -307,7 +307,7 @@ def pair(
     :returns: List of opinion dicts with page ranges, bboxes, and
         outside_rects.
     """
-    from blackletter.models import BBox, Detection as BLDetection, Document, Label, Page
+    from blackletter.models import Detection as BLDetection, Document, Label, Page
     from blackletter.scanner import _pair_opinions, _outside_opinion_rects
 
     pdf_path = Path(pdf_path)
@@ -319,19 +319,10 @@ def pair(
         raw = detections
 
     # Build Document
+    from blackletter.scanner import _group_detections_by_page
+
     src_pdf = fitz.open(str(pdf_path))
-    pages_data = {}
-    for entry in raw:
-        pi = entry["page_index"]
-        if pi not in pages_data:
-            pages_data[pi] = {
-                "page_number": entry.get("page_number"),
-                "page_number_end": entry.get("page_number_end"),
-                "img_width": entry.get("img_width", 1),
-                "img_height": entry.get("img_height", 1),
-                "detections": [],
-            }
-        pages_data[pi]["detections"].append(entry)
+    pages_data = _group_detections_by_page(raw, include_page_number_end=True)
 
     pages = []
     for pi in sorted(pages_data.keys()):
@@ -350,15 +341,7 @@ def pair(
             page_number_end=pd.get("page_number_end"),
         )
         for d in pd["detections"]:
-            b = d.get("bbox", [0, 0, 1, 1])
-            page.detections.append(
-                BLDetection(
-                    bbox=BBox(x1=b[0], y1=b[1], x2=b[2], y2=b[3]),
-                    label=Label(d["label_id"]),
-                    confidence=d["confidence"],
-                    page_index=pi,
-                )
-            )
+            page.detections.append(BLDetection.from_raw_dict(d, pi, bbox_default=[0, 0, 1, 1]))
         if page.page_number is None:
             page.page_number = pi + first_page
         pages.append(page)

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -43,9 +43,7 @@ def bitonal(
         invoked during processing.
     :returns: Path to the bitonal PDF.
     """
-    import io
-    import numpy as np
-    from PIL import Image
+    from blackletter.ocr import _render_bitonal_page
 
     pdf_path = Path(pdf_path)
     output_dir = Path(output_dir)
@@ -57,14 +55,7 @@ def bitonal(
     total = src.page_count
 
     for i in range(total):
-        page = src[i]
-        new_page = out.new_page(width=page.rect.width, height=page.rect.height)
-        pix = page.get_pixmap(dpi=dpi, colorspace=fitz.csGRAY)
-        gray = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
-        bw = Image.fromarray((gray > threshold).astype(np.uint8) * 255).convert("1")
-        buf = io.BytesIO()
-        bw.save(buf, format="TIFF", compression="group4")
-        new_page.insert_image(new_page.rect, stream=buf.getvalue())
+        _render_bitonal_page(src[i], out, dpi, threshold)
         if progress_callback and ((i + 1) % 10 == 0 or i == total - 1):
             progress_callback(i + 1, total, f"Bitonal: {i + 1}/{total} pages")
         if (i + 1) % 50 == 0 or i == total - 1:
@@ -95,7 +86,7 @@ def ocr(
     :param language: Tesseract language code.
     :returns: Path to the OCR'd PDF.
     """
-    import logging
+    from blackletter.ocr import _silence_ocr_loggers
 
     pdf_path = Path(pdf_path)
     output_dir = Path(output_dir)
@@ -108,11 +99,7 @@ def ocr(
     scan_name = ".".join(parts) if parts else pdf_path.stem
     output_path = output_dir / f"{scan_name}.pdf"
 
-    for name in ("pikepdf", "fontTools", "fontTools.subset", "fontTools.ttLib", "ocrmypdf"):
-        logging.getLogger(name).setLevel(logging.ERROR)
-    for _n in list(logging.root.manager.loggerDict):
-        if _n.startswith("ocrmypdf"):
-            logging.getLogger(_n).setLevel(logging.ERROR)
+    _silence_ocr_loggers()
 
     import ocrmypdf
 
@@ -944,34 +931,3 @@ def generate(
         "masked_dir": masked_dir,
         "opinion_count": len(opinions),
     }
-
-
-def margins(
-    pdf_path: str | Path,
-    output_dir: str | Path,
-) -> list[dict]:
-    """Compute margin rects and save margin_rects.json.
-
-    Skips computation if margin_rects.json already exists in
-    *output_dir*.
-
-    :param pdf_path: Path to the source PDF.
-    :param output_dir: Directory to write margin_rects.json into.
-    :returns: List of margin rect dicts.
-    """
-    from blackletter.margins import compute_margin_rects
-
-    pdf_path = Path(pdf_path)
-    output_dir = Path(output_dir)
-
-    margin_path = output_dir / "margin_rects.json"
-    if margin_path.exists():
-        print("  Margins already computed, skipping.", flush=True)
-        return json.loads(margin_path.read_text())
-
-    t0 = time.time()
-    print("  Computing margins...", flush=True)
-    rects = compute_margin_rects(pdf_path)
-    margin_path.write_text(json.dumps(rects))
-    print(f"  Margins done ({time.time() - t0:.0f}s)", flush=True)
-    return rects

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -148,8 +148,9 @@ def detect(
 
     model_map = {"small": "small.pt", "medium": "medium.pt", "large": "large.pt"}
 
+    from blackletter.scanner import DPI, YOLO_BATCH
+
     pdf = fitz.open(str(pdf_path))
-    DPI = 200
     mat = fitz.Matrix(DPI / 72, DPI / 72)
     total = pdf.page_count
 
@@ -164,9 +165,8 @@ def detect(
         print(f"  Detecting with {model_name}...", flush=True)
         t0 = time.time()
 
-        BATCH = 4
-        for bs in range(0, total, BATCH):
-            be = min(bs + BATCH, total)
+        for bs in range(0, total, YOLO_BATCH):
+            be = min(bs + YOLO_BATCH, total)
             imgs = []
             metas = []
             for i in range(bs, be):
@@ -195,8 +195,8 @@ def detect(
                             "model": model_name,
                         }
                     )
-            if (bs + BATCH) % 100 == 0 or bs + BATCH >= total:
-                print(f"    {min(bs + BATCH, total)}/{total} pages", flush=True)
+            if (bs + YOLO_BATCH) % 100 == 0 or bs + YOLO_BATCH >= total:
+                print(f"    {min(bs + YOLO_BATCH, total)}/{total} pages", flush=True)
 
         print(f"    {model_name} done ({time.time() - t0:.0f}s)", flush=True)
 
@@ -307,8 +307,8 @@ def pair(
     :returns: List of opinion dicts with page ranges, bboxes, and
         outside_rects.
     """
-    from blackletter.models import Detection as BLDetection, Document, Label, Page
-    from blackletter.scanner import _pair_opinions, _outside_opinion_rects
+    from blackletter.models import Detection as BLDetection, Document, Page
+    from blackletter.scanner import _pair_opinions
 
     pdf_path = Path(pdf_path)
 
@@ -366,76 +366,24 @@ def pair(
         page_ranges.append((caption.page_index, key.page_index))
 
     # Save opinions.json
+    from blackletter.scanner import _build_opinions_data, _opinion_page_bounds
+
     pages_by_index = {p.index: p for p in document.pages}
-    opinions_data = []
-    for idx, (caption, key) in enumerate(opinions):
+    opinions_data = _build_opinions_data(opinions, pages_by_index, src_pdf)
+
+    # Augment each entry with filename-inference fields unique to this API
+    for idx, entry in enumerate(opinions_data):
         start_idx, end_idx = page_ranges[idx]
-        outside_rects = []
-        for pi in range(start_idx, end_idx + 1):
-            pg = pages_by_index.get(pi)
-            if not pg:
-                continue
-            is_first = pi == start_idx
-            is_last = pi == end_idx
-            pw = src_pdf[pi].rect.width if pi < src_pdf.page_count else 612.0
-            for rect in _outside_opinion_rects(pg, pw, caption, key, is_first, is_last):
-                outside_rects.append(
-                    {
-                        "page_index": pi,
-                        "x0": round(rect.x0, 1),
-                        "y0": round(rect.y0, 1),
-                        "x1": round(rect.x1, 1),
-                        "y1": round(rect.y1, 1),
-                    }
-                )
-        has_image = any(
-            d.label == Label.IMAGE
-            for pi2 in range(start_idx, end_idx + 1)
-            if pi2 in pages_by_index
-            for d in pages_by_index[pi2].detections
+        first_num, last_num = _opinion_page_bounds(
+            pages_by_index.get(start_idx),
+            pages_by_index.get(end_idx),
+            start_idx,
+            end_idx,
+            first_page,
         )
-
-        # For naming: opinion starting on a range page uses end number,
-        # ending on a range page uses first number
-        start_page = pages_by_index.get(start_idx)
-        end_page = pages_by_index.get(end_idx)
-        if start_page and start_page.page_number_end:
-            first_num = start_page.page_number_end
-        elif start_page and start_page.page_number:
-            first_num = start_page.page_number
-        else:
-            first_num = start_idx + first_page
-        if end_page and end_page.page_number_end:
-            last_num = end_page.page_number
-        elif end_page and end_page.page_number:
-            last_num = end_page.page_number
-        else:
-            last_num = end_idx + first_page
-
-        opinions_data.append(
-            {
-                "caption_page": caption.page_index,
-                "caption_bbox": [
-                    round(caption.bbox.x1, 1),
-                    round(caption.bbox.y1, 1),
-                    round(caption.bbox.x2, 1),
-                    round(caption.bbox.y2, 1),
-                ],
-                "key_page": key.page_index,
-                "key_bbox": [
-                    round(key.bbox.x1, 1),
-                    round(key.bbox.y1, 1),
-                    round(key.bbox.x2, 1),
-                    round(key.bbox.y2, 1),
-                ],
-                "end_page": end_idx,
-                "page_count": end_idx - start_idx + 1,
-                "first_page_number": first_num,
-                "last_page_number": last_num,
-                "outside_rects": outside_rects,
-                "has_image": has_image,
-            }
-        )
+        entry["end_page"] = end_idx
+        entry["first_page_number"] = first_num
+        entry["last_page_number"] = last_num
 
     src_pdf.close()
 

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 
@@ -677,7 +678,7 @@ def generate(
     :returns: Dict with keys ``redacted_dir``, ``masked_dir``,
         ``full_redacted``, and ``opinion_count``.
     """
-    import re as _re
+    import re
 
     # Labels to white-out in masked output instead of black
     WHITE_IN_MASKED = {"PAGE_HEADER", "STATE_ABBREVIATION"}
@@ -716,16 +717,14 @@ def generate(
         return op.get("filename", f"{op['caption_page']:04d}-{op['end_page']:04d}.pdf")
 
     # Detect duplicate filenames and add -1/-2/-3 suffixes
-    from collections import Counter as _Counter
-
     raw_names = [_opinion_filename(op) for op in opinions]
-    name_counts = _Counter(raw_names)
+    name_counts = Counter(raw_names)
     name_seq: dict[str, int] = {}
     filenames = []
     for name in raw_names:
         if name_counts[name] > 1:
             name_seq[name] = name_seq.get(name, 0) + 1
-            filenames.append(_re.sub(r"\.pdf$", f"-{name_seq[name]}.pdf", name))
+            filenames.append(re.sub(r"\.pdf$", f"-{name_seq[name]}.pdf", name))
         else:
             filenames.append(name)
 
@@ -907,7 +906,7 @@ def generate(
 
             # Filename: strip the -1/-2/-3 suffix from first opinion's computed name
             base_name = filenames[group[0]]
-            base_name = _re.sub(r"-\d+\.pdf$", ".pdf", base_name)
+            base_name = re.sub(r"-\d+\.pdf$", ".pdf", base_name)
 
             out = fitz.open()
             out.insert_pdf(src, from_page=src_page_idx, to_page=src_page_idx)

--- a/blackletter/margins.py
+++ b/blackletter/margins.py
@@ -23,8 +23,11 @@ def _text_bounds(
 ) -> tuple[float, float, float, float] | None:
     """Find the bounding box of all text and images on a page.
 
-    Returns (left, top, right, bottom) in PDF points, or None if the text
-    doesn't span enough of the page to justify margin cleanup.
+    :param fitz_page: A PyMuPDF page object.
+    :param page_width: Width of the page in PDF points.
+    :returns: ``(left, top, right, bottom)`` in PDF points, or ``None``
+        if the text doesn't span enough of the page to justify margin
+        cleanup.
     """
     blocks = fitz_page.get_text("blocks")
     text_blocks = [b for b in blocks if b[6] == 0 and b[4].strip()]
@@ -36,12 +39,12 @@ def _text_bounds(
     right = max(b[2] for b in text_blocks)
     bottom = max(b[3] for b in text_blocks)
 
-    # Skip pages where text is too narrow — likely an appendix or image page
+    # Skip pages where text is too narrow, likely an appendix or image page
     if (right - left) < page_width * MIN_TEXT_WIDTH_FRACTION:
         return None
 
-    # Extend bounds to include image blocks (e.g. key icons at page bottom)
-    # Only extend vertically — images outside the text column are margin artifacts
+    # Extend bounds to include image blocks (e.g. key icons at page bottom).
+    # Only extend vertically; images outside the text column are margin artifacts
     img_blocks = [b for b in blocks if b[6] == 1]
     for b in img_blocks:
         # Only consider images that overlap the text column horizontally
@@ -58,7 +61,10 @@ def compute_margin_rects(
 ) -> list[dict]:
     """Compute margin rects for each page without applying them.
 
-    Returns list of {page_index, rects: [{x0, y0, x1, y1}]}.
+    :param pdf_path: Path to the input PDF file.
+    :param buffer: Safety buffer in PDF points around the content area.
+    :returns: List of dicts with ``page_index`` and ``rects`` keys, where
+        each rect is a dict with ``x0``, ``y0``, ``x1``, ``y1``.
     """
     pdf_path = Path(pdf_path)
     doc = fitz.open(str(pdf_path))
@@ -121,9 +127,11 @@ def clean_margins(
     applies white redactions to the four margin strips (left, right,
     top, bottom) with a safety buffer around the content.
 
-    Modifies the PDF in-place if output_path is None.
-
-    Returns the output path.
+    :param pdf_path: Path to the input PDF file.
+    :param buffer: Safety buffer in PDF points around the content area.
+    :param output_path: Where to write the cleaned PDF. If ``None``,
+        modifies the PDF in-place.
+    :returns: The output path.
     """
     pdf_path = Path(pdf_path)
     if output_path is None:
@@ -132,7 +140,7 @@ def clean_margins(
     doc = fitz.open(str(pdf_path))
     cleaned = 0
 
-    # Detect bitonal — apply_redactions corrupts CCITT G4 streams
+    # Detect bitonal. apply_redactions corrupts CCITT G4 streams
     _sample_imgs = doc[0].get_images(full=True) if doc.page_count else []
     is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
 
@@ -200,7 +208,7 @@ def clean_margins(
         cleaned += 1
 
     if not is_bitonal:
-        # Recompress images — apply_redactions converts JPEGs to PNG, inflating size
+        # Recompress images. apply_redactions converts JPEGs to PNG, inflating size
         from blackletter.scanner import recompress_images
 
         recompress_images(doc, quality=65)
@@ -208,7 +216,7 @@ def clean_margins(
     total = len(doc)
 
     if output_path == pdf_path:
-        # Can't save over the source directly — use temp file
+        # Can't save over the source directly, use temp file
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False, dir=pdf_path.parent) as tmp:
             tmp_path = Path(tmp.name)
         doc.save(str(tmp_path), garbage=4, deflate=True)

--- a/blackletter/models.py
+++ b/blackletter/models.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import IntEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import fitz
 
 
 class Label(IntEnum):
@@ -118,6 +122,21 @@ class BBox:
             x2=self.x2 * scale_x,
             y2=self.y2 * scale_y,
         )
+
+    def to_fitz_pdf_rect(self, scale_x: float, scale_y: float) -> fitz.Rect:
+        """Scale to PDF points and wrap as a ``fitz.Rect``.
+
+        Combines :meth:`to_pdf` and ``fitz.Rect(...)`` for the common
+        redaction-pipeline idiom.
+
+        :param scale_x: Horizontal pixels-to-points ratio.
+        :param scale_y: Vertical pixels-to-points ratio.
+        :returns: ``fitz.Rect`` in PDF point coordinates.
+        """
+        import fitz
+
+        b = self.to_pdf(scale_x, scale_y)
+        return fitz.Rect(b.x1, b.y1, b.x2, b.y2)
 
     def _intersection_area(self, other: BBox) -> float:
         """Return the area of the overlap rectangle with ``other`` (``0`` if disjoint)."""

--- a/blackletter/models.py
+++ b/blackletter/models.py
@@ -78,7 +78,11 @@ class BBox:
 
     @classmethod
     def from_xyxy(cls, coords: list[float]) -> BBox:
-        """Create from YOLO xyxy output: [x1, y1, x2, y2]."""
+        """Create from YOLO xyxy output: [x1, y1, x2, y2].
+
+        :param coords: Flat list of four floats [x1, y1, x2, y2].
+        :returns: A new BBox instance.
+        """
         return cls(coords[0], coords[1], coords[2], coords[3])
 
     @property
@@ -102,7 +106,12 @@ class BBox:
         return self.width * self.height
 
     def to_pdf(self, scale_x: float, scale_y: float) -> BBox:
-        """Convert pixel coordinates to PDF points."""
+        """Convert pixel coordinates to PDF points.
+
+        :param scale_x: Horizontal pixels-to-points ratio.
+        :param scale_y: Vertical pixels-to-points ratio.
+        :returns: A new BBox in PDF point coordinates.
+        """
         return BBox(
             x1=self.x1 * scale_x,
             y1=self.y1 * scale_y,
@@ -111,7 +120,11 @@ class BBox:
         )
 
     def iou(self, other: BBox) -> float:
-        """Intersection over union with another box."""
+        """Intersection over union with another box.
+
+        :param other: The box to compare against.
+        :returns: IoU value in the range [0, 1].
+        """
         ix1 = max(self.x1, other.x1)
         iy1 = max(self.y1, other.y1)
         ix2 = min(self.x2, other.x2)
@@ -121,7 +134,12 @@ class BBox:
         return inter / union if union > 0 else 0.0
 
     def contains(self, other: BBox, threshold: float = 0.8) -> bool:
-        """True if `other` is mostly inside this box."""
+        """True if ``other`` is mostly inside this box.
+
+        :param other: The candidate inner box.
+        :param threshold: Minimum fraction of ``other`` that must overlap.
+        :returns: Whether the overlap fraction meets the threshold.
+        """
         ix1 = max(self.x1, other.x1)
         iy1 = max(self.y1, other.y1)
         ix2 = min(self.x2, other.x2)
@@ -144,11 +162,19 @@ class Detection:
         return self.label.is_copyrighted
 
     def column(self, midpoint: float) -> str:
-        """Which column this detection falls in relative to a midpoint (pixels)."""
+        """Which column this detection falls in relative to a midpoint.
+
+        :param midpoint: Horizontal pixel coordinate dividing left/right columns.
+        :returns: ``"LEFT"`` or ``"RIGHT"``.
+        """
         return "LEFT" if self.bbox.center_x < midpoint else "RIGHT"
 
     def sort_key(self, midpoint: float) -> tuple[int, int, float]:
-        """Key for reading order: page, then column (L=0, R=1), then y position."""
+        """Key for reading order: page, then column (L=0, R=1), then y position.
+
+        :param midpoint: Horizontal pixel coordinate dividing left/right columns.
+        :returns: Tuple of (page_index, column_ordinal, y1).
+        """
         col_ord = 0 if self.bbox.center_x < midpoint else 1
         return (self.page_index, col_ord, self.bbox.y1)
 
@@ -197,7 +223,11 @@ class Page:
         return self.pdf_height / self.img_height
 
     def by_label(self, *labels: Label) -> list[Detection]:
-        """Filter detections by one or more labels."""
+        """Filter detections by one or more labels.
+
+        :param labels: One or more Label values to keep.
+        :returns: List of matching detections.
+        """
         label_set = set(labels)
         return [d for d in self.detections if d.label in label_set]
 
@@ -222,7 +252,11 @@ class Document:
     ocr_applied: bool = False
 
     def by_label(self, *labels: Label) -> list[Detection]:
-        """All detections matching the given labels, in reading order."""
+        """All detections matching the given labels, in reading order.
+
+        :param labels: One or more Label values to keep.
+        :returns: List of matching detections sorted in reading order.
+        """
         hits = [d for p in self.pages for d in p.by_label(*labels)]
         if self.pages:
             mid = self.pages[0].midpoint

--- a/blackletter/models.py
+++ b/blackletter/models.py
@@ -157,6 +157,30 @@ class Detection:
     confidence: float
     page_index: int
 
+    @classmethod
+    def from_raw_dict(
+        cls,
+        d: dict,
+        page_index: int,
+        bbox_default: list[float] | None = None,
+    ) -> Detection:
+        """Reconstruct a :class:`Detection` from a JSON-serialised sidecar row.
+
+        :param d: Row dict with keys ``label_id``, ``confidence``, and
+            ``bbox`` (list of 4 floats: x1, y1, x2, y2).
+        :param page_index: Page index this detection belongs to.
+        :param bbox_default: If supplied, a missing ``bbox`` key falls
+            back to this list; otherwise a ``KeyError`` propagates.
+        :returns: A new :class:`Detection`.
+        """
+        bbox = d["bbox"] if bbox_default is None else d.get("bbox", bbox_default)
+        return cls(
+            bbox=BBox(x1=bbox[0], y1=bbox[1], x2=bbox[2], y2=bbox[3]),
+            label=Label(d["label_id"]),
+            confidence=d["confidence"],
+            page_index=page_index,
+        )
+
     @property
     def is_copyrighted(self) -> bool:
         return self.label.is_copyrighted

--- a/blackletter/models.py
+++ b/blackletter/models.py
@@ -119,17 +119,21 @@ class BBox:
             y2=self.y2 * scale_y,
         )
 
+    def _intersection_area(self, other: BBox) -> float:
+        """Return the area of the overlap rectangle with ``other`` (``0`` if disjoint)."""
+        ix1 = max(self.x1, other.x1)
+        iy1 = max(self.y1, other.y1)
+        ix2 = min(self.x2, other.x2)
+        iy2 = min(self.y2, other.y2)
+        return max(0, ix2 - ix1) * max(0, iy2 - iy1)
+
     def iou(self, other: BBox) -> float:
         """Intersection over union with another box.
 
         :param other: The box to compare against.
         :returns: IoU value in the range [0, 1].
         """
-        ix1 = max(self.x1, other.x1)
-        iy1 = max(self.y1, other.y1)
-        ix2 = min(self.x2, other.x2)
-        iy2 = min(self.y2, other.y2)
-        inter = max(0, ix2 - ix1) * max(0, iy2 - iy1)
+        inter = self._intersection_area(other)
         union = self.area + other.area - inter
         return inter / union if union > 0 else 0.0
 
@@ -140,11 +144,7 @@ class BBox:
         :param threshold: Minimum fraction of ``other`` that must overlap.
         :returns: Whether the overlap fraction meets the threshold.
         """
-        ix1 = max(self.x1, other.x1)
-        iy1 = max(self.y1, other.y1)
-        ix2 = min(self.x2, other.x2)
-        iy2 = min(self.y2, other.y2)
-        inter = max(0, ix2 - ix1) * max(0, iy2 - iy1)
+        inter = self._intersection_area(other)
         return (inter / other.area) >= threshold if other.area > 0 else False
 
 

--- a/blackletter/ocr.py
+++ b/blackletter/ocr.py
@@ -33,6 +33,42 @@ DEFAULT_TARGET_KB = 148
 # Don't go below this DPI — text becomes unreadable
 MIN_DPI = 100
 
+_NOISY_OCR_LOGGERS = ("pikepdf", "fontTools", "fontTools.subset", "fontTools.ttLib", "ocrmypdf")
+
+
+def _silence_ocr_loggers() -> None:
+    """Raise noisy ocrmypdf/pikepdf/fontTools loggers to ERROR level."""
+    for name in _NOISY_OCR_LOGGERS:
+        logging.getLogger(name).setLevel(logging.ERROR)
+    for name in list(logging.root.manager.loggerDict):
+        if name.startswith("ocrmypdf"):
+            logging.getLogger(name).setLevel(logging.ERROR)
+
+
+def _render_bitonal_page(
+    src_page: fitz.Page,
+    out_doc: fitz.Document,
+    dpi: int,
+    threshold: int,
+) -> None:
+    """Render ``src_page`` as a 1-bit CCITT G4 TIFF and append it to ``out_doc``.
+
+    :param src_page: Source page to rasterize.
+    :param out_doc: Destination ``fitz.Document`` the rendered page is
+        appended to (via ``new_page`` + ``insert_image``).
+    :param dpi: Render DPI.
+    :param threshold: Grayscale threshold (0-255) for binarisation.
+    """
+    import numpy as np
+
+    new_page = out_doc.new_page(width=src_page.rect.width, height=src_page.rect.height)
+    pix = src_page.get_pixmap(dpi=dpi, colorspace=fitz.csGRAY)
+    gray = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
+    bw = Image.fromarray((gray > threshold).astype(np.uint8) * 255).convert("1")
+    buf = io.BytesIO()
+    bw.save(buf, format="TIFF", compression="group4")
+    new_page.insert_image(new_page.rect, stream=buf.getvalue())
+
 
 def needs_ocr(pdf_path: Path, sample_pages: int = 3) -> bool:
     """Check if a PDF needs OCR (has no usable text layer).
@@ -359,13 +395,9 @@ print("DONE", flush=True)
 
         # Merge chunks back into one PDF
         print("  OCR: merging chunks...", flush=True)
-        merged = fitz.open()
-        for c_out in chunk_outputs:
-            chunk_doc = fitz.open(str(c_out))
-            merged.insert_pdf(chunk_doc)
-            chunk_doc.close()
-        merged.save(str(output_path), garbage=4, deflate=True)
-        merged.close()
+        from blackletter.tasks import merge_pdfs
+
+        merge_pdfs(chunk_outputs, output_path)
 
         # Cleanup
         for f in chunk_inputs + chunk_outputs:
@@ -373,12 +405,7 @@ print("DONE", flush=True)
     else:
         # ── Single-process OCR for small documents ──
         print(f"  OCR step 2: Adding text layer (tesseract) — {n_pages} pages...", flush=True)
-        for name in ("pikepdf", "fontTools", "fontTools.subset", "fontTools.ttLib"):
-            logging.getLogger(name).setLevel(logging.ERROR)
-        logging.getLogger("ocrmypdf").setLevel(logging.ERROR)
-        for _log_name in list(logging.root.manager.loggerDict):
-            if _log_name.startswith("ocrmypdf"):
-                logging.getLogger(_log_name).setLevel(logging.ERROR)
+        _silence_ocr_loggers()
 
         import ocrmypdf as _ocrmypdf
         from ocrmypdf import hookimpl as _hookimpl
@@ -548,32 +575,19 @@ def bitonal_convert(
                 _time.sleep(0.5)
 
         # Merge chunks
-        merged = fitz.open()
-        for chunk_out in chunk_outputs:
-            chunk_doc = fitz.open(str(chunk_out))
-            merged.insert_pdf(chunk_doc)
-            chunk_doc.close()
-        merged.save(str(dst_path), garbage=4, deflate=True)
-        merged.close()
+        from blackletter.tasks import merge_pdfs
+
+        merge_pdfs(chunk_outputs, dst_path)
 
         for f in chunk_outputs:
             f.unlink(missing_ok=True)
         worker_script.unlink(missing_ok=True)
     else:
         # Single-process for small docs
-        import numpy as np
-
         src = fitz.open(str(src_path))
         out = fitz.open()
         for i in range(total):
-            page = src[i]
-            new_page = out.new_page(width=page.rect.width, height=page.rect.height)
-            pix = page.get_pixmap(dpi=dpi, colorspace=fitz.csGRAY)
-            gray = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
-            bw = Image.fromarray((gray > threshold).astype(np.uint8) * 255).convert("1")
-            buf = io.BytesIO()
-            bw.save(buf, format="TIFF", compression="group4")
-            new_page.insert_image(new_page.rect, stream=buf.getvalue())
+            _render_bitonal_page(src[i], out, dpi, threshold)
             if (i + 1) % 20 == 0 or (i + 1) == total:
                 print(f"  Bitonal: {i + 1}/{total}", flush=True)
         out.save(str(dst_path), garbage=4, deflate=True)

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -1069,7 +1069,8 @@ def cmd_process(args: argparse.Namespace) -> None:
     shrink = not getattr(args, "no_shrink", False)
 
     # Build output name: reporter.volume.firstpage.lastpage
-    page_count = len(fitz.open(str(args.pdf)))
+    with fitz.open(str(args.pdf)) as _pdf_for_count:
+        page_count = len(_pdf_for_count)
     # Prefer the last_page from filename parsing over computing from page count
     last_page = inferred.get("last_page") or (args.first_page + page_count - 1)
     parts = []

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -20,6 +20,7 @@ from blackletter.scanner import (
     _pair_opinions,
     _check_excluded,
     _outside_opinion_rects,
+    _group_detections_by_page,
     _make_add_safe,
     _iter_case_sequence_rects,
     _clip_headnote_rect,
@@ -1590,7 +1591,7 @@ def rebuild_full_redacted_from_detections(
     (with optional exclusions), and calls _build_full_redacted.
     """
     import json as _json
-    from blackletter.models import BBox, Detection, Document, Label, Page
+    from blackletter.models import Detection, Document, Page
 
     detections_json_path = Path(detections_json_path)
     ocr_pdf_path = Path(ocr_pdf_path)
@@ -1607,17 +1608,7 @@ def rebuild_full_redacted_from_detections(
     src_pdf.close()
 
     # Group detections by page_index
-    pages_data: dict[int, dict] = {}
-    for entry in raw:
-        pi = entry["page_index"]
-        if pi not in pages_data:
-            pages_data[pi] = {
-                "page_number": entry.get("page_number"),
-                "img_width": entry.get("img_width", 1),
-                "img_height": entry.get("img_height", 1),
-                "detections": [],
-            }
-        pages_data[pi]["detections"].append(entry)
+    pages_data = _group_detections_by_page(raw)
 
     pages = []
     for pi in sorted(pages_data.keys()):
@@ -1632,15 +1623,7 @@ def rebuild_full_redacted_from_detections(
             page_number=pd["page_number"],
         )
         for d in pd["detections"]:
-            bbox = d["bbox"]
-            page.detections.append(
-                Detection(
-                    bbox=BBox(bbox[0], bbox[1], bbox[2], bbox[3]),
-                    label=Label(d["label_id"]),
-                    confidence=d["confidence"],
-                    page_index=pi,
-                )
-            )
+            page.detections.append(Detection.from_raw_dict(d, pi))
         pages.append(page)
 
     document = Document(
@@ -1746,7 +1729,7 @@ def generate_files(
     """
     import json as _json
     import time as _time
-    from blackletter.models import BBox, Detection, Document, Label, Page
+    from blackletter.models import Detection, Document, Page
 
     _t_total = _time.time()
     ocr_pdf = Path(ocr_pdf)
@@ -1782,18 +1765,7 @@ def generate_files(
         page_dims[i] = (r.width, r.height)
     src_pdf.close()
 
-    pages_data: dict[int, dict] = {}
-    for entry in raw:
-        pi = entry["page_index"]
-        if pi not in pages_data:
-            pages_data[pi] = {
-                "page_number": entry.get("page_number"),
-                "page_number_end": entry.get("page_number_end"),
-                "img_width": entry.get("img_width", 1),
-                "img_height": entry.get("img_height", 1),
-                "detections": [],
-            }
-        pages_data[pi]["detections"].append(entry)
+    pages_data = _group_detections_by_page(raw, include_page_number_end=True)
 
     # Load page metadata (column bounds) if available
     _pages_meta = {}
@@ -1822,15 +1794,7 @@ def generate_files(
             midpoint=meta.get("midpoint", 0),
         )
         for d in pd["detections"]:
-            bbox_raw = d.get("bbox", [0, 0, 1, 1])
-            page.detections.append(
-                Detection(
-                    bbox=BBox(x1=bbox_raw[0], y1=bbox_raw[1], x2=bbox_raw[2], y2=bbox_raw[3]),
-                    label=Label(d["label_id"]),
-                    confidence=d["confidence"],
-                    page_index=pi,
-                )
-            )
+            page.detections.append(Detection.from_raw_dict(d, pi, bbox_default=[0, 0, 1, 1]))
         # Fill in missing page numbers from first_page offset
         if page.page_number is None:
             page.page_number = pi + first_page

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -21,6 +21,8 @@ from blackletter.scanner import (
     _check_excluded,
     _outside_opinion_rects,
     _group_detections_by_page,
+    _collect_page_number_rects,
+    _opinion_page_bounds,
     _make_add_safe,
     _iter_case_sequence_rects,
     _clip_headnote_rect,
@@ -161,13 +163,7 @@ def _build_masked_opinions(
         sx, sy = page.scale_x, page.scale_y
 
         # Collect page number rects — never redact these
-        pn_rects = []
-        for d in page.detections:
-            if d.label == Label.PAGE_NUMBER:
-                b = d.bbox.to_pdf(sx, sy)
-                r = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
-                tight = _tighten_to_text(fitz_page, r, skip=False)
-                pn_rects.append(tight if tight is not None else r)
+        pn_rects = _collect_page_number_rects(page, fitz_page, sx, sy)
 
         add_safe = _make_add_safe(fitz_page, pn_rects)
 
@@ -235,8 +231,7 @@ def _build_masked_opinions(
                 sk = d.sort_key(mid)
                 if sk < cap_key or sk > key_key:
                     continue
-            b = d.bbox.to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
             tight = _tighten_to_text(fitz_page, rect, skip=False)
             if tight is not None:
                 rect = tight
@@ -257,8 +252,7 @@ def _build_masked_opinions(
                 continue
             if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
                 continue
-            b = d.bbox.to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
             sk = d.sort_key(mid)
             if sk < cap_key or sk > key_key:
                 add_safe(rect, (1, 1, 1))
@@ -269,8 +263,7 @@ def _build_masked_opinions(
         _caption_rects = []
         for d in page.detections:
             if d.label == Label.CASE_CAPTION:
-                b = d.bbox.to_pdf(sx, sy)
-                _caption_rects.append(fitz.Rect(b.x1, b.y1, b.x2, b.y2))
+                _caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
         for rect in _iter_case_sequence_rects(page, sx, sy, _caption_rects, excluded):
             add_safe(rect, (0, 0, 0))
 
@@ -514,8 +507,7 @@ def compute_redaction_rects(
                 _add_px(src_idx, d.bbox.x1, d.bbox.y1, d.bbox.x2, d.bbox.y2, fill, d.label.name)
             else:
                 # Tighten in PDF coords, convert back to pixels
-                b = d.bbox.to_pdf(sx, sy)
-                rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+                rect = d.bbox.to_fitz_pdf_rect(sx, sy)
                 tight = _tighten_to_text(fitz_page, rect, skip=False)
                 if tight is not None:
                     rect = tight
@@ -534,8 +526,7 @@ def compute_redaction_rects(
         caption_rects = []
         for d in page.detections:
             if d.label == Label.CASE_CAPTION:
-                b = d.bbox.to_pdf(sx, sy)
-                caption_rects.append(fitz.Rect(b.x1, b.y1, b.x2, b.y2))
+                caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
 
         _CS_INSET = 3.0
         _CS_MIN_PX = 40  # min width/height in image pixels
@@ -553,8 +544,7 @@ def compute_redaction_rects(
             ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
             bx0, bx1 = cx - pw / 2, cx + pw / 2
             by0, by1 = cy - ph / 2, cy + ph / 2
-            b = BBox(bx0, by0, bx1, by1).to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            rect = BBox(bx0, by0, bx1, by1).to_fitz_pdf_rect(sx, sy)
             # Small inset
             rect = fitz.Rect(
                 rect.x0 + _CS_INSET,
@@ -635,25 +625,13 @@ def _split_from_redacted(
     _bases: list[str] = []
     for idx, (caption, _key) in enumerate(opinions):
         start_idx, end_idx = page_ranges[idx]
-        start_page = pages_by_index.get(start_idx)
-        end_page = pages_by_index.get(end_idx)
-
-        # Opinion starting on a range page → use end number
-        if start_page and start_page.page_number_end:
-            first_num = start_page.page_number_end
-        elif start_page and start_page.page_number:
-            first_num = start_page.page_number
-        else:
-            first_num = start_idx + first_page
-
-        # Opinion ending on a range page → use first number
-        if end_page and end_page.page_number_end:
-            last_num = end_page.page_number
-        elif end_page and end_page.page_number:
-            last_num = end_page.page_number
-        else:
-            last_num = end_idx + first_page
-
+        first_num, last_num = _opinion_page_bounds(
+            pages_by_index.get(start_idx),
+            pages_by_index.get(end_idx),
+            start_idx,
+            end_idx,
+            first_page,
+        )
         _bases.append(f"{_reporter}.{_volume}.{first_num:04d}-{last_num:04d}")
 
     _name_counts = _Counter(_bases)
@@ -850,20 +828,13 @@ def _build_full_redacted(
         sx, sy = page.scale_x, page.scale_y
 
         # Collect page number rects — never redact these
-        pn_rects = []
-        for d in page.detections:
-            if d.label == Label.PAGE_NUMBER:
-                b = d.bbox.to_pdf(sx, sy)
-                r = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
-                tight = _tighten_to_text(fitz_page, r, skip=False)
-                pn_rects.append(tight if tight is not None else r)
+        pn_rects = _collect_page_number_rects(page, fitz_page, sx, sy)
 
         # Collect caption rects — CASE_SEQUENCE must not overlap these
         caption_rects = []
         for d in page.detections:
             if d.label == Label.CASE_CAPTION:
-                b = d.bbox.to_pdf(sx, sy)
-                caption_rects.append(fitz.Rect(b.x1, b.y1, b.x2, b.y2))
+                caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
 
         page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
         add_safe = _make_add_safe(fitz_page, pn_rects, collector=page_redact_rects)
@@ -890,8 +861,7 @@ def _build_full_redacted(
                 continue
             if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
                 continue
-            b = d.bbox.to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
             _skip_tighten = d.label in (Label.HEADNOTE_BRACKET, Label.STATE_ABBREVIATION)
             if not _skip_tighten:
                 tight = _tighten_to_text(fitz_page, rect, skip=False)
@@ -920,8 +890,7 @@ def _build_full_redacted(
                 continue
             if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
                 continue
-            b = d.bbox.to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
             add_safe(rect, (0, 0, 0))
 
         if is_bitonal and page_redact_rects:
@@ -986,8 +955,7 @@ def _extract_images(document, output_dir: Path) -> int:
         images.sort(key=lambda d: d.sort_key(page.midpoint))
 
         for seq, det in enumerate(images, start=1):
-            b = det.bbox.to_pdf(sx, sy)
-            clip = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+            clip = det.bbox.to_fitz_pdf_rect(sx, sy)
             pix = fitz_page.get_pixmap(matrix=mat, clip=clip)
 
             # Use detected page number, fall back to index + first_page

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -20,6 +20,10 @@ from blackletter.scanner import (
     _pair_opinions,
     _check_excluded,
     _outside_opinion_rects,
+    _make_add_safe,
+    _iter_case_sequence_rects,
+    _clip_headnote_rect,
+    _write_pages_meta_sidecar,
     _margin_bounds,
     _find_redaction_end,
     _headnote_fallback_rects,
@@ -164,23 +168,7 @@ def _build_masked_opinions(
                 tight = _tighten_to_text(fitz_page, r, skip=False)
                 pn_rects.append(tight if tight is not None else r)
 
-        def add_safe(rect: fitz.Rect, fill) -> None:
-            if rect.is_empty:
-                return
-            for pn in pn_rects:
-                if rect.intersects(pn):
-                    if rect.y0 < pn.y0:
-                        add_safe(fitz.Rect(rect.x0, rect.y0, rect.x1, pn.y0), fill)
-                    if rect.y1 > pn.y1:
-                        add_safe(fitz.Rect(rect.x0, pn.y1, rect.x1, rect.y1), fill)
-                    top = max(rect.y0, pn.y0)
-                    bot = min(rect.y1, pn.y1)
-                    if rect.x0 < pn.x0 and top < bot:
-                        add_safe(fitz.Rect(rect.x0, top, pn.x0, bot), fill)
-                    if rect.x1 > pn.x1 and top < bot:
-                        add_safe(fitz.Rect(pn.x1, top, rect.x1, bot), fill)
-                    return
-            fitz_page.add_redact_annot(rect, fill=fill)
+        add_safe = _make_add_safe(fitz_page, pn_rects)
 
         # Outside-opinion whiteout: treat the group as one mega-opinion
         # from first caption to last key
@@ -222,28 +210,13 @@ def _build_masked_opinions(
             if headnote_rects:
                 header_bottom, footer_top = _margin_bounds(page)
                 for rect_page_idx, rect in headnote_rects:
-                    if rect_page_idx == src_page_idx:
-                        if not document.ocr_applied:
-                            tight = _tighten_to_text(fitz_page, rect)
-                            if tight is not None:
-                                rect = tight
-                            text_bot = _text_bottom(fitz_page, rect)
-                            text_left, text_right = _text_x_bounds(fitz_page, rect)
-                            rect = fitz.Rect(
-                                max(rect.x0, text_left),
-                                max(rect.y0, header_bottom),
-                                min(rect.x1, text_right),
-                                min(rect.y1, footer_top, text_bot),
-                            )
-                        else:
-                            rect = fitz.Rect(
-                                rect.x0,
-                                max(rect.y0, header_bottom),
-                                rect.x1,
-                                min(rect.y1, footer_top),
-                            )
-                        if rect.y0 < rect.y1 and rect.x0 < rect.x1:
-                            add_safe(rect, (0, 0, 0))
+                    if rect_page_idx != src_page_idx:
+                        continue
+                    clipped = _clip_headnote_rect(
+                        fitz_page, rect, header_bottom, footer_top, document.ocr_applied
+                    )
+                    if clipped is not None:
+                        add_safe(clipped, (0, 0, 0))
 
         # Per-detection redactions (within the mega-span)
         # STATE_ABBREVIATION lives above the first caption so treat it like
@@ -297,37 +270,7 @@ def _build_masked_opinions(
             if d.label == Label.CASE_CAPTION:
                 b = d.bbox.to_pdf(sx, sy)
                 _caption_rects.append(fitz.Rect(b.x1, b.y1, b.x2, b.y2))
-        _CS_INSET = 3.0
-        _CS_MIN_PX, _CS_MAX_PX = 40, 60
-        for d in page.detections:
-            if d.label != Label.CASE_SEQUENCE:
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            bx0, by0 = d.bbox.x1, d.bbox.y1
-            bx1, by1 = d.bbox.x2, d.bbox.y2
-            cx, cy = (bx0 + bx1) / 2, (by0 + by1) / 2
-            pw = max(_CS_MIN_PX, min(bx1 - bx0, _CS_MAX_PX))
-            ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
-            bx0, bx1 = cx - pw / 2, cx + pw / 2
-            by0, by1 = cy - ph / 2, cy + ph / 2
-            from blackletter.models import BBox as _BBox
-
-            b = _BBox(bx0, by0, bx1, by1).to_pdf(sx, sy)
-            rect = fitz.Rect(
-                b.x1 + _CS_INSET,
-                b.y1 + _CS_INSET,
-                b.x2 - _CS_INSET,
-                b.y2 - _CS_INSET,
-            )
-            for cap_r in _caption_rects:
-                if rect.intersects(cap_r):
-                    if rect.y0 < cap_r.y0:
-                        rect = fitz.Rect(rect.x0, rect.y0, rect.x1, cap_r.y0)
-                    else:
-                        rect = fitz.Rect(0, 0, 0, 0)
-            if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
-                continue
+        for rect in _iter_case_sequence_rects(page, sx, sy, _caption_rects, excluded):
             add_safe(rect, (0, 0, 0))
 
         fitz_page.apply_redactions()
@@ -921,44 +864,22 @@ def _build_full_redacted(
                 b = d.bbox.to_pdf(sx, sy)
                 caption_rects.append(fitz.Rect(b.x1, b.y1, b.x2, b.y2))
 
-        page_redact_rects = []
-
-        def add_safe(rect: fitz.Rect, fill) -> None:
-            if rect.is_empty:
-                return
-            for pn in pn_rects:
-                if rect.intersects(pn):
-                    if rect.y0 < pn.y0:
-                        add_safe(fitz.Rect(rect.x0, rect.y0, rect.x1, pn.y0), fill)
-                    if rect.y1 > pn.y1:
-                        add_safe(fitz.Rect(rect.x0, pn.y1, rect.x1, rect.y1), fill)
-                    top = max(rect.y0, pn.y0)
-                    bot = min(rect.y1, pn.y1)
-                    if rect.x0 < pn.x0 and top < bot:
-                        add_safe(fitz.Rect(rect.x0, top, pn.x0, bot), fill)
-                    if rect.x1 > pn.x1 and top < bot:
-                        add_safe(fitz.Rect(pn.x1, top, rect.x1, bot), fill)
-                    return
-            page_redact_rects.append((fitz.Rect(rect), fill))
-            fitz_page.add_redact_annot(rect, fill=fill)
+        page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
+        add_safe = _make_add_safe(fitz_page, pn_rects, collector=page_redact_rects)
 
         # Headnote blackout
         header_bottom, footer_top = _margin_bounds(page)
         for rect_page_idx, rect in all_headnote_rects:
-            if rect_page_idx == src_idx:
-                tight = _tighten_to_text(fitz_page, rect)
-                if tight is not None:
-                    rect = tight
-                text_bot = _text_bottom(fitz_page, rect)
-                text_left, text_right = _text_x_bounds(fitz_page, rect)
-                rect = fitz.Rect(
-                    max(rect.x0, text_left),
-                    max(rect.y0, header_bottom),
-                    min(rect.x1, text_right),
-                    min(rect.y1, footer_top, text_bot),
-                )
-                if rect.y0 < rect.y1 and rect.x0 < rect.x1:
-                    add_safe(rect, (0, 0, 0))
+            if rect_page_idx != src_idx:
+                continue
+            # `_build_full_redacted` always runs on post-OCR PDFs so text bounds
+            # are reliable; match that by passing ocr_applied=False to get the
+            # text-tightening branch.
+            clipped = _clip_headnote_rect(
+                fitz_page, rect, header_bottom, footer_top, ocr_applied=False
+            )
+            if clipped is not None:
+                add_safe(clipped, (0, 0, 0))
 
         # Per-detection redactions
         for d in page.detections:
@@ -979,43 +900,7 @@ def _build_full_redacted(
             add_safe(rect, fill)
 
         # CASE_SEQUENCE: redact black, but never overlap CASE_CAPTION
-        _CS_INSET = 3.0
-        _CS_MIN_PX = 40
-        _CS_MAX_PX = 60
-        for d in page.detections:
-            if d.label != Label.CASE_SEQUENCE:
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            # Clamp to min/max pixels, then convert to PDF points
-            bx0, by0 = d.bbox.x1, d.bbox.y1
-            bx1, by1 = d.bbox.x2, d.bbox.y2
-            cx, cy = (bx0 + bx1) / 2, (by0 + by1) / 2
-            pw = max(_CS_MIN_PX, min(bx1 - bx0, _CS_MAX_PX))
-            ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
-            bx0, bx1 = cx - pw / 2, cx + pw / 2
-            by0, by1 = cy - ph / 2, cy + ph / 2
-            from blackletter.models import BBox
-
-            b = BBox(bx0, by0, bx1, by1).to_pdf(sx, sy)
-            rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
-            rect = fitz.Rect(
-                rect.x0 + _CS_INSET,
-                rect.y0 + _CS_INSET,
-                rect.x1 - _CS_INSET,
-                rect.y1 - _CS_INSET,
-            )
-            # Clip away any overlap with caption rects
-            for cap_r in caption_rects:
-                if rect.intersects(cap_r):
-                    if rect.y0 < cap_r.y0:
-                        # Sequence box hangs into the caption from above — trim its bottom
-                        rect = fitz.Rect(rect.x0, rect.y0, rect.x1, cap_r.y0)
-                    else:
-                        # Sequence box starts inside the caption — skip entirely
-                        rect = fitz.Rect(0, 0, 0, 0)
-            if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
-                continue
+        for rect in _iter_case_sequence_rects(page, sx, sy, caption_rects, excluded):
             add_safe(rect, (0, 0, 0))
 
         # Key icon redactions (always black, ratio-filtered only)
@@ -1280,17 +1165,7 @@ def cmd_process(args: argparse.Namespace) -> None:
     print(f"  Saved {len(detections_data)} detections to {detections_path.name}")
 
     # Save page metadata (column bounds, midpoint) for re-pair
-    pages_meta = {}
-    for _page in document.pages:
-        pages_meta[_page.index] = {
-            "col_left_x1": _page.col_left_x1,
-            "col_left_x2": _page.col_left_x2,
-            "col_right_x1": _page.col_right_x1,
-            "col_right_x2": _page.col_right_x2,
-            "midpoint": _page.midpoint,
-        }
-    with open(base_dir / "pages_meta.json", "w") as _f:
-        _json.dump(pages_meta, _f)
+    _write_pages_meta_sidecar(document, base_dir)
 
     # ── Auto-fill missing STATE_ABBREVIATION with large model ──
     _pages_by_idx = {p.index: p for p in document.pages}
@@ -1366,56 +1241,6 @@ def cmd_process(args: argparse.Namespace) -> None:
     print("\nPairing opinions...", flush=True)
     opinions = _pair_opinions(document, excluded=excluded)
     print(f"  Found {len(opinions)} opinions ({_time.time() - _t0:.0f}s)", flush=True)
-
-    pages_by_index = {p.index: p for p in document.pages}
-    _src_pdf = fitz.open(str(document.pdf_path))
-    opinions_data = []
-    for caption, key in opinions:
-        # Compute outside-opinion rects for each page in this opinion
-        outside_rects = []
-        for pi in range(caption.page_index, key.page_index + 1):
-            page = pages_by_index[pi]
-            is_first = pi == caption.page_index
-            is_last = pi == key.page_index
-            pw = _src_pdf[pi].rect.width
-            for rect in _outside_opinion_rects(page, pw, caption, key, is_first, is_last):
-                outside_rects.append(
-                    {
-                        "page_index": pi,
-                        "x0": round(rect.x0, 1),
-                        "y0": round(rect.y0, 1),
-                        "x1": round(rect.x1, 1),
-                        "y1": round(rect.y1, 1),
-                    }
-                )
-        opinions_data.append(
-            {
-                "caption_page": caption.page_index,
-                "caption_label": caption.label.name,
-                "caption_bbox": [
-                    round(caption.bbox.x1, 1),
-                    round(caption.bbox.y1, 1),
-                    round(caption.bbox.x2, 1),
-                    round(caption.bbox.y2, 1),
-                ],
-                "key_page": key.page_index,
-                "key_label": key.label.name,
-                "key_bbox": [
-                    round(key.bbox.x1, 1),
-                    round(key.bbox.y1, 1),
-                    round(key.bbox.x2, 1),
-                    round(key.bbox.y2, 1),
-                ],
-                "page_count": key.page_index - caption.page_index + 1,
-                "outside_rects": outside_rects,
-                "has_image": any(
-                    d.label == Label.IMAGE
-                    for pi2 in range(caption.page_index, key.page_index + 1)
-                    for d in pages_by_index[pi2].detections
-                ),
-            }
-        )
-    _src_pdf.close()
 
     # ── Precompute redaction rects (with tightening) for review ──
     _t0 = _time.time()

--- a/blackletter/scanner.py
+++ b/blackletter/scanner.py
@@ -7,6 +7,7 @@ import logging
 import re
 import subprocess
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 import cv2
@@ -72,11 +73,17 @@ def _check_excluded(
     excluded: "set[tuple[int, int, int, int]] | None",
     tolerance: int = _EXCLUSION_TOLERANCE,
 ) -> bool:
-    """Return True if detection d matches any entry in excluded.
+    """Return True if detection *d* matches any entry in *excluded*.
 
     Matches on (page_index, label_id) exactly, then checks bbox origin
-    within ±tolerance pixels to handle minor YOLO coordinate variation
+    within +/-tolerance pixels to handle minor YOLO coordinate variation
     between scans of the same PDF.
+
+    :param d: Detection to check.
+    :param excluded: Set of (page_index, label_id, bbox_x1, bbox_y1)
+        tuples to suppress.
+    :param tolerance: Maximum pixel distance for fuzzy bbox matching.
+    :returns: ``True`` if the detection is excluded.
     """
     if not excluded:
         return False
@@ -102,10 +109,14 @@ def _filter_key_icons_by_size(
     """Keep only KEY_ICON detections whose size is close to the median.
 
     Key icons are all the same symbol, so valid detections should have
-    very similar bounding-box dimensions.  We compute the median width
+    very similar bounding-box dimensions. We compute the median width
     and height from high-confidence detections (>= 0.75) and reject any
     detection whose width or height deviates by more than *tolerance*
     from that median.
+
+    :param detections: Full list of detections (all labels).
+    :param tolerance: Max allowed deviation from median as a fraction.
+    :returns: Filtered detection list.
     """
     from statistics import median
 
@@ -154,10 +165,10 @@ def detect_columns(
 ) -> tuple[float, float, float, float, float]:
     """Detect left/right column boundaries from image using projection analysis.
 
-    Ported from blackletter's detect_columns_from_image.
-
-    Returns (left_x1, left_x2, right_x1, right_x2, center_X) in pixels.
-    Raises ValueError on failure.
+    :param img_bgr: BGR image as a numpy array.
+    :returns: Tuple of (left_x1, left_x2, right_x1, right_x2, center_x)
+        in pixels.
+    :raises ValueError: If column detection fails.
     """
     h, w = img_bgr.shape[:2]
     gray = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2GRAY)
@@ -343,7 +354,7 @@ def _extract_page_number(
     # Determine max expected digits from the hint
     max_digits = max(4, len(str(hint)) + 1) if hint > 0 else 5
 
-    # Method 1: PDF text layer — fast, try this first
+    # Method 1: PDF text layer, fast, try this first
     pdf_text = fitz_page.get_text("text", clip=rect).strip()
 
     # Check for page range first
@@ -361,7 +372,7 @@ def _extract_page_number(
         if _plausible(n, hint, max_digits):
             return (n, None)
 
-    # Method 2: tesseract OCR — only if text layer failed
+    # Method 2: tesseract OCR, only if text layer failed
     # Try modes in order; stop as soon as we get a plausible result
     ocr_results: list[int] = []
     for psm in (8, 7, 13):
@@ -412,7 +423,7 @@ def validate_page_numbers(document: Document) -> list[str]:
         if p.page_number is None:
             warnings.append(f"Page index {p.index}: no page number detected")
 
-    # Check sequential consistency — look for gaps
+    # Check sequential consistency, look for gaps
     for i in range(1, len(numbered)):
         prev_idx, prev_num = numbered[i - 1]
         curr_idx, curr_num = numbered[i]
@@ -542,7 +553,7 @@ def scan(
     optimize: int = 1,
     output_name: str | None = None,
     device: str | None = None,
-    progress_callback=None,
+    progress_callback: Callable[[int, int, str], None] | None = None,
 ) -> Document:
     """Scan a PDF and return a Document with all detections.
 
@@ -550,11 +561,19 @@ def scan(
     one (required for accurate page number extraction and redaction
     tightening).
 
-    If shrink=True, downsample images to ~148 KB/page even if the PDF
-    already has a text layer.
-
-    If skip_ocr=True, never run OCR regardless of text layer presence
-    (use when the PDF is already known to have a text layer).
+    :param pdf_path: Path to the source PDF.
+    :param model: Loaded YOLO model instance.
+    :param confidence: Minimum confidence threshold for detections.
+    :param first_page: First page number of the volume.
+    :param output_dir: Directory for intermediate and output files.
+    :param shrink: Downsample images to ~148 KB/page even if the PDF
+        already has a text layer.
+    :param skip_ocr: Never run OCR regardless of text layer presence.
+    :param optimize: OCR optimization level (passed to ocrmypdf).
+    :param output_name: Custom stem for output filenames.
+    :param device: YOLO inference device (e.g. ``"cpu"``, ``"cuda:0"``).
+    :param progress_callback: Optional callable(current, total, message).
+    :returns: Document with all detections populated.
     """
     from blackletter.ocr import needs_ocr, ocr_pdf, _downsample_pdf
 
@@ -567,7 +586,7 @@ def scan(
     actual_path = _fix_rotated_pages(pdf_path, dest_dir, out_stem)
 
     if not skip_ocr and needs_ocr(actual_path):
-        print("  PDF has no text layer — running OCR...")
+        print("  PDF has no text layer, running OCR...")
         ocr_out = dest_dir / f"{out_stem}.pdf"
         ocr_pdf(actual_path, ocr_out, optimize=optimize)
         orig_mb = actual_path.stat().st_size / (1024 * 1024)
@@ -575,7 +594,7 @@ def scan(
         final_mb = ocr_out.stat().st_size / (1024 * 1024)
         print(f"  OCR complete: {orig_mb:.1f} MB -> {final_mb:.1f} MB ({ocr_out.name})")
     elif shrink:
-        # Skip downsample for bitonal (1-bit) PDFs — already compact
+        # Skip downsample for bitonal (1-bit) PDFs, already compact
         _chk = fitz.open(str(actual_path))
         _imgs = _chk[0].get_images(full=True) if _chk.page_count else []
         _is_bitonal = bool(_imgs and _imgs[0][4] == 1)
@@ -912,16 +931,14 @@ def draw_detections(
 ) -> Path:
     """Draw bounding boxes on the PDF and write an annotated copy.
 
-    Uses PyMuPDF to draw directly on the PDF pages — no rasterization needed.
+    Uses PyMuPDF to draw directly on the PDF pages (no rasterization).
 
-    Args:
-        pdf_path: Path to the source PDF.
-        document: Scanned Document with detections.
-        output_path: Path for the output PDF.
-        labels: If provided, only draw these labels. None = draw all.
-
-    Returns:
-        Path to the written PDF.
+    :param pdf_path: Path to the source PDF.
+    :param document: Scanned Document with detections.
+    :param output_path: Path for the output PDF.
+    :param labels: If provided, only draw these labels. ``None`` draws
+        all.
+    :returns: Path to the written PDF.
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     pdf = fitz.open(pdf_path)
@@ -950,17 +967,16 @@ def _pair_opinions(
 ) -> list[tuple[Detection, Detection]]:
     """Pair each CASE_CAPTION with the next KEY_ICON in reading order.
 
-    Key icons are the reliable anchor.  After each key icon, the first
-    caption that follows starts the next opinion.  A BACKGROUND detection
-    can also signal the end of a multi-page caption (the opinion text
-    begins after the background region).
+    Key icons are the reliable anchor. After each key icon, the first
+    caption that follows starts the next opinion. Only the first caption
+    after a key icon is used; subsequent captions before the next key
+    icon are ignored to avoid false-positive splits.
 
-    Only the first caption after a key icon is used; subsequent captions
-    before the next key icon are ignored to avoid false-positive splits.
-
-    Args:
-        excluded: Optional set of (page_index, label_id, round(bbox_x1), round(bbox_y1))
-                  tuples to suppress specific detections.
+    :param document: Document with pages and detections.
+    :param excluded: Optional set of (page_index, label_id,
+        round(bbox_x1), round(bbox_y1)) tuples to suppress specific
+        detections.
+    :returns: List of (caption, key) detection pairs.
     """
 
     def _is_excluded(d):
@@ -1215,11 +1231,11 @@ def _text_x_bounds(fitz_page, clip: fitz.Rect, padding: float = 2.0) -> tuple[fl
 def _column_bounds_pdf(page: Page) -> tuple[float, float, float, float, float] | None:
     """Return (left_x0, left_x1, right_x0, right_x1, col_boundary) in PDF points.
 
-    Uses TEXT_COLUMN detections — the same source of truth used for
+    Uses TEXT_COLUMN detections (the same source of truth used for
     headnote redaction snapping.  Returns None if no TEXT_COLUMN
     detections are available (caller should skip masking for that page).
 
-    col_boundary is the midpoint of the gap between columns — used to
+    col_boundary is the midpoint of the gap between columns) used to
     decide which column a detection belongs to.
     """
     sx, sy = page.scale_x, page.scale_y
@@ -1697,7 +1713,7 @@ def split_opinions(
 
     Modes:
         debug (draw_labels + debug_redactions): bounding boxes and red overlays
-        redact: actual PDF redactions — white for outside-opinion content,
+        redact: actual PDF redactions, white for outside-opinion content,
                 black for headnote zones, white for headers/state abbrevs/dividers
 
     redact_mode overrides the redact boolean when set:
@@ -1843,7 +1859,7 @@ def split_opinions(
                 # ── Actual redaction mode ──────────────────────────
                 sx, sy = page.scale_x, page.scale_y
 
-                # Collect page number rects — these must never be redacted
+                # Collect page number rects (these must never be redacted)
                 pn_rects = []
                 for d in page.detections:
                     if d.label == Label.PAGE_NUMBER:
@@ -1940,7 +1956,7 @@ def split_opinions(
                                 min(rect.y1, footer_top, text_bot),
                             )
                         else:
-                            # No reliable text layer — just clip to margins
+                            # No reliable text layer, just clip to margins
                             rect = fitz.Rect(
                                 rect.x0,
                                 max(rect.y0, header_bottom),
@@ -2000,10 +2016,10 @@ def split_opinions(
                     rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
                     sk = d.sort_key(mid)
                     if sk < cap_key or sk > key_key:
-                        # Outside opinion bounds — always white
+                        # Outside opinion bounds, always white
                         add_safe(rect, (1, 1, 1))
                     else:
-                        # Within opinion (including own key) — black
+                        # Within opinion (including own key), black
                         add_safe(rect, (0, 0, 0))
 
                 if _is_bitonal and _page_redact_rects:
@@ -2073,7 +2089,7 @@ def split_opinions(
                 shape.commit()
 
         # For masked mode, remove pages that are fully headnotes
-        # Use block-level rects (pre-refinement) for coverage — line-level rects
+        # Use block-level rects (pre-refinement) for coverage. Line-level rects
         # have gaps between lines and won't reliably sum to >=95%.
         if redact_mode == "masked" and block_headnote_rects:
             pages_to_delete: list[int] = []

--- a/blackletter/scanner.py
+++ b/blackletter/scanner.py
@@ -7,7 +7,7 @@ import logging
 import re
 import subprocess
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import cv2
@@ -264,6 +264,24 @@ def detect_columns(
     )
 
 
+def _safe_detect_columns(
+    img_rgb: Image.Image,
+) -> tuple[float, float, float, float, float]:
+    """Convert RGB PIL image to BGR and run :func:`detect_columns`.
+
+    Returns ``(0, 0, 0, 0, 0)`` if detection fails, so callers can keep
+    processing pages without a hard failure.
+
+    :param img_rgb: Page image as a PIL ``Image`` in RGB.
+    :returns: Column-bound tuple matching :func:`detect_columns`.
+    """
+    img_bgr = cv2.cvtColor(np.array(img_rgb), cv2.COLOR_RGB2BGR)
+    try:
+        return detect_columns(img_bgr)
+    except Exception:
+        return 0.0, 0.0, 0.0, 0.0, 0.0
+
+
 def _ocr_region(fitz_page, rect: fitz.Rect, psm: int = 7) -> str:
     """Run tesseract OCR on a page region, digits only.
 
@@ -354,15 +372,22 @@ def _extract_page_number(
     # Determine max expected digits from the hint
     max_digits = max(4, len(str(hint)) + 1) if hint > 0 else 5
 
+    def _range_if_plausible(text: str) -> tuple[int, int] | None:
+        """Return a plausible (a, b) range parsed from ``text``, else None."""
+        parsed = _parse_page_range(text)
+        if parsed and len(parsed) == 2:
+            a, b = parsed
+            if _plausible(a, hint, max_digits) or _plausible(b, hint, max_digits):
+                return (a, b)
+        return None
+
     # Method 1: PDF text layer, fast, try this first
     pdf_text = fitz_page.get_text("text", clip=rect).strip()
 
     # Check for page range first
-    parsed = _parse_page_range(pdf_text)
-    if parsed and len(parsed) == 2:
-        a, b = parsed
-        if _plausible(a, hint, max_digits) or _plausible(b, hint, max_digits):
-            return (a, b)
+    rng = _range_if_plausible(pdf_text)
+    if rng is not None:
+        return rng
 
     pdf_digits = re.sub(r"\D", "", pdf_text)
 
@@ -379,11 +404,9 @@ def _extract_page_number(
         raw = _ocr_region(fitz_page, rect, psm=psm)
         if raw:
             # Check for range in OCR output too
-            parsed = _parse_page_range(raw)
-            if parsed and len(parsed) == 2:
-                a, b = parsed
-                if _plausible(a, hint, max_digits) or _plausible(b, hint, max_digits):
-                    return (a, b)
+            rng = _range_if_plausible(raw)
+            if rng is not None:
+                return rng
             digits = re.sub(r"\D", "", raw)
             if digits:
                 n = int(digits)
@@ -403,38 +426,6 @@ def _extract_page_number(
             n = min(candidates, key=lambda n: len(str(n)))
         return (n, None)
     return None
-
-
-def validate_page_numbers(document: Document) -> list[str]:
-    """Check page number sequence for gaps and mismatches.
-
-    Returns a list of warning strings (empty if everything looks good).
-    """
-    warnings: list[str] = []
-
-    numbered = [(p.index, p.page_number) for p in document.pages if p.page_number is not None]
-
-    if not numbered:
-        warnings.append("No page numbers detected in document")
-        return warnings
-
-    # Check for pages with no detected number
-    for p in document.pages:
-        if p.page_number is None:
-            warnings.append(f"Page index {p.index}: no page number detected")
-
-    # Check sequential consistency, look for gaps
-    for i in range(1, len(numbered)):
-        prev_idx, prev_num = numbered[i - 1]
-        curr_idx, curr_num = numbered[i]
-        expected = prev_num + (curr_idx - prev_idx)
-        if curr_num != expected:
-            warnings.append(
-                f"Page index {curr_idx}: expected page {expected}, "
-                f"got {curr_num} (gap or misnumber after index {prev_idx}={prev_num})"
-            )
-
-    return warnings
 
 
 def _fix_rotated_pages(pdf_path: Path, dest_dir: Path, stem: str) -> Path:
@@ -480,7 +471,7 @@ from PIL import Image
 from ultralytics import YOLO
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from blackletter.scanner import detect_columns, _extract_page_number, DPI
+from blackletter.scanner import _safe_detect_columns, _extract_page_number, DPI
 from blackletter.models import Label
 
 pdf_path, model_path = sys.argv[1], sys.argv[2]
@@ -502,11 +493,7 @@ for bs in range(page_start, page_end, BATCH):
         pix = fp.get_pixmap(matrix=mat)
         img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
         imgs.append(img)
-        img_bgr = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
-        try:
-            lx1, lx2, rx1, rx2, mid = detect_columns(img_bgr)
-        except Exception:
-            lx1, lx2, rx1, rx2, mid = 0, 0, 0, 0, 0
+        lx1, lx2, rx1, rx2, mid = _safe_detect_columns(img)
         meta.append((pi, fp.rect.width, fp.rect.height, pix.width, pix.height, (lx1, lx2, rx1, rx2, mid)))
 
     results = model(imgs, conf=confidence, verbose=False, device=None)
@@ -656,13 +643,9 @@ def scan(
         model_path = (
             Path(model.ckpt_path) if hasattr(model, "ckpt_path") else Path(str(model.model))
         )
-        chunk_size = (total_pages + n_workers - 1) // n_workers
-        chunks = []
-        for i in range(n_workers):
-            s = i * chunk_size
-            e = min(s + chunk_size, total_pages)
-            if s < e:
-                chunks.append((s, e))
+        from blackletter.tasks import split_page_ranges
+
+        chunks = split_page_ranges(total_pages, n_workers)
 
         # Write worker script to temp file
         worker_script = Path(tempfile.gettempdir()) / "_bl_scan_worker.py"
@@ -778,11 +761,7 @@ def scan(
                 pix = fitz_page.get_pixmap(matrix=mat)
                 img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
                 imgs.append(img)
-                img_bgr = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
-                try:
-                    lx1, lx2, rx1, rx2, mid = detect_columns(img_bgr)
-                except (ValueError, Exception):
-                    lx1, lx2, rx1, rx2, mid = 0, 0, 0, 0, 0
+                lx1, lx2, rx1, rx2, mid = _safe_detect_columns(img)
                 meta.append((page_idx, fitz_page, pix.width, pix.height, (lx1, lx2, rx1, rx2, mid)))
             return imgs, meta
 
@@ -852,13 +831,29 @@ def scan(
     return doc
 
 
-def _page_num_for_sequence(page: Page) -> int | None:
-    """Return the best page_number to use for sequential checks.
+def _nearest_numbered_neighbor(
+    pages: list[Page],
+    i: int,
+    step: int,
+    max_look: int,
+) -> tuple[int | None, int]:
+    """Scan up to ``max_look`` pages in direction ``step`` from index ``i``.
 
-    For a range like 31-32, both are valid; callers pick based on context.
-    For sequence checking, use page_number (the lower/first value).
+    :param pages: Pages to scan over.
+    :param i: Index to start from (exclusive).
+    :param step: ``-1`` to scan before, ``+1`` to scan after.
+    :param max_look: Maximum distance to search.
+    :returns: ``(page_number, distance)`` of the nearest page with a
+        non-null ``page_number``, or ``(None, 0)`` if none is found.
     """
-    return page.page_number
+    n = len(pages)
+    for dist in range(1, max_look + 1):
+        j = i + step * dist
+        if not 0 <= j < n:
+            return None, 0
+        if pages[j].page_number is not None:
+            return pages[j].page_number, dist
+    return None, 0
 
 
 def _correct_page_numbers(pages: list[Page]) -> None:
@@ -881,23 +876,8 @@ def _correct_page_numbers(pages: list[Page]) -> None:
     for _pass in range(5):  # up to 5 correction passes
         corrections = 0
         for i in range(n):
-            # Find nearest valid neighbor before
-            prev_num = None
-            prev_dist = 0
-            for j in range(i - 1, max(i - max_look - 1, -1), -1):
-                if pages[j].page_number is not None:
-                    prev_num = pages[j].page_number
-                    prev_dist = i - j
-                    break
-
-            # Find nearest valid neighbor after
-            next_num = None
-            next_dist = 0
-            for j in range(i + 1, min(i + max_look + 1, n)):
-                if pages[j].page_number is not None:
-                    next_num = pages[j].page_number
-                    next_dist = j - i
-                    break
+            prev_num, prev_dist = _nearest_numbered_neighbor(pages, i, -1, max_look)
+            next_num, next_dist = _nearest_numbered_neighbor(pages, i, +1, max_look)
 
             if prev_num is None or next_num is None:
                 continue
@@ -1300,6 +1280,279 @@ def _outside_opinion_rects(
             rects.append(fitz.Rect(right_x0, header_bottom, right_x1, footer_top))
 
     return [r for r in rects if r.y0 < r.y1 and r.x0 < r.x1]
+
+
+def _build_opinions_data(
+    opinions: list[tuple[Detection, Detection]],
+    pages_by_index: dict[int, Page],
+    src_pdf: fitz.Document,
+) -> list[dict]:
+    """Serialise paired opinions to the opinions.json dict shape.
+
+    For each ``(caption, key)`` pair this computes the per-page
+    ``_outside_opinion_rects`` and assembles the metadata dict written
+    to ``opinions.json``.
+
+    :param opinions: Paired ``(caption, key)`` detections from
+        :func:`_pair_opinions`.
+    :param pages_by_index: Mapping of page index to :class:`Page`.
+    :param src_pdf: Open source PDF used to look up per-page widths.
+    :returns: List of opinion dicts ready for JSON serialisation.
+    """
+    opinions_data: list[dict] = []
+    for caption, key in opinions:
+        outside_rects: list[dict] = []
+        for pi in range(caption.page_index, key.page_index + 1):
+            page = pages_by_index.get(pi)
+            if page is None:
+                continue
+            is_first = pi == caption.page_index
+            is_last = pi == key.page_index
+            pw = src_pdf[pi].rect.width
+            for rect in _outside_opinion_rects(page, pw, caption, key, is_first, is_last):
+                outside_rects.append(
+                    {
+                        "page_index": pi,
+                        "x0": round(rect.x0, 1),
+                        "y0": round(rect.y0, 1),
+                        "x1": round(rect.x1, 1),
+                        "y1": round(rect.y1, 1),
+                    }
+                )
+        has_image = any(
+            d.label == Label.IMAGE
+            for pi2 in range(caption.page_index, key.page_index + 1)
+            if pi2 in pages_by_index
+            for d in pages_by_index[pi2].detections
+        )
+        opinions_data.append(
+            {
+                "caption_page": caption.page_index,
+                "caption_label": caption.label.name,
+                "caption_bbox": [
+                    round(caption.bbox.x1, 1),
+                    round(caption.bbox.y1, 1),
+                    round(caption.bbox.x2, 1),
+                    round(caption.bbox.y2, 1),
+                ],
+                "key_page": key.page_index,
+                "key_label": key.label.name,
+                "key_bbox": [
+                    round(key.bbox.x1, 1),
+                    round(key.bbox.y1, 1),
+                    round(key.bbox.x2, 1),
+                    round(key.bbox.y2, 1),
+                ],
+                "page_count": key.page_index - caption.page_index + 1,
+                "outside_rects": outside_rects,
+                "has_image": has_image,
+            }
+        )
+    return opinions_data
+
+
+def _make_add_safe(
+    fitz_page,
+    pn_rects: list[fitz.Rect],
+    collector: list[tuple[fitz.Rect, tuple]] | None = None,
+) -> Callable[[fitz.Rect, tuple], None]:
+    """Build a recursive rect-adder that clips around page-number boxes.
+
+    The returned closure adds ``(rect, fill)`` as a PyMuPDF redaction
+    annotation unless the rect intersects any page-number rect, in which
+    case it splits the rect into up-to-four non-overlapping slices and
+    recurses.
+
+    :param fitz_page: Page to attach redaction annotations to.
+    :param pn_rects: Page-number rectangles to preserve (never redact).
+    :param collector: If provided, each ``(rect, fill)`` pair that ends
+        up annotated is also appended here (used for bitonal-safe
+        redaction where the image pixels must be overwritten directly).
+    :returns: The ``add_safe`` closure.
+    """
+
+    def add_safe(rect: fitz.Rect, fill) -> None:
+        if rect.is_empty:
+            return
+        for pn in pn_rects:
+            if rect.intersects(pn):
+                if rect.y0 < pn.y0:
+                    add_safe(fitz.Rect(rect.x0, rect.y0, rect.x1, pn.y0), fill)
+                if rect.y1 > pn.y1:
+                    add_safe(fitz.Rect(rect.x0, pn.y1, rect.x1, rect.y1), fill)
+                top = max(rect.y0, pn.y0)
+                bot = min(rect.y1, pn.y1)
+                if rect.x0 < pn.x0 and top < bot:
+                    add_safe(fitz.Rect(rect.x0, top, pn.x0, bot), fill)
+                if rect.x1 > pn.x1 and top < bot:
+                    add_safe(fitz.Rect(pn.x1, top, rect.x1, bot), fill)
+                return
+        if collector is not None:
+            collector.append((fitz.Rect(rect), fill))
+        fitz_page.add_redact_annot(rect, fill=fill)
+
+    return add_safe
+
+
+_CS_INSET = 3.0
+_CS_MIN_PX = 40
+_CS_MAX_PX = 60
+
+
+def _iter_case_sequence_rects(
+    page: Page,
+    sx: float,
+    sy: float,
+    caption_rects: list[fitz.Rect],
+    excluded: set | None,
+) -> Iterator[fitz.Rect]:
+    """Yield PDF-point redaction rects for every CASE_SEQUENCE detection.
+
+    Applies the 40-60 px clamp, 3 pt inset, and caption-overlap clipping.
+    Skips excluded detections and rects that end up empty.
+
+    :param page: Page whose detections are scanned.
+    :param sx: Horizontal image-to-PDF scale factor.
+    :param sy: Vertical image-to-PDF scale factor.
+    :param caption_rects: PDF-point CASE_CAPTION rects on this page; any
+        CASE_SEQUENCE rect that overlaps a caption is trimmed to the
+        area above it or dropped entirely.
+    :param excluded: Set of excluded detection-bbox tuples, or ``None``.
+    """
+    from blackletter.models import BBox
+
+    for d in page.detections:
+        if d.label != Label.CASE_SEQUENCE:
+            continue
+        if _check_excluded(d, excluded):
+            continue
+        bx0, by0 = d.bbox.x1, d.bbox.y1
+        bx1, by1 = d.bbox.x2, d.bbox.y2
+        cx, cy = (bx0 + bx1) / 2, (by0 + by1) / 2
+        pw = max(_CS_MIN_PX, min(bx1 - bx0, _CS_MAX_PX))
+        ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
+        bx0, bx1 = cx - pw / 2, cx + pw / 2
+        by0, by1 = cy - ph / 2, cy + ph / 2
+        b = BBox(bx0, by0, bx1, by1).to_pdf(sx, sy)
+        rect = fitz.Rect(
+            b.x1 + _CS_INSET,
+            b.y1 + _CS_INSET,
+            b.x2 - _CS_INSET,
+            b.y2 - _CS_INSET,
+        )
+        for cap_r in caption_rects:
+            if rect.intersects(cap_r):
+                if rect.y0 < cap_r.y0:
+                    rect = fitz.Rect(rect.x0, rect.y0, rect.x1, cap_r.y0)
+                else:
+                    rect = fitz.Rect(0, 0, 0, 0)
+        if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
+            continue
+        yield rect
+
+
+def _clip_headnote_rect(
+    fitz_page,
+    rect: fitz.Rect,
+    header_bottom: float,
+    footer_top: float,
+    ocr_applied: bool,
+) -> fitz.Rect | None:
+    """Tighten a headnote rect to page text and clamp it to margin bounds.
+
+    When ``ocr_applied`` is True the rect is only clamped to
+    ``(header_bottom, footer_top)``; when False it is further
+    ``_tighten_to_text``-adjusted and clipped to text bounds on all four
+    sides. Returns ``None`` when the resulting rect has no area.
+
+    :param fitz_page: PyMuPDF page used to measure text bounds.
+    :param rect: Input rect in PDF points.
+    :param header_bottom: Upper Y cut-off (from :func:`_margin_bounds`).
+    :param footer_top: Lower Y cut-off (from :func:`_margin_bounds`).
+    :param ocr_applied: Whether the PDF has a reliable text layer.
+    :returns: The clipped rect, or ``None`` if degenerate.
+    """
+    if not ocr_applied:
+        tight = _tighten_to_text(fitz_page, rect)
+        if tight is not None:
+            rect = tight
+        text_bot = _text_bottom(fitz_page, rect)
+        text_left, text_right = _text_x_bounds(fitz_page, rect)
+        rect = fitz.Rect(
+            max(rect.x0, text_left),
+            max(rect.y0, header_bottom),
+            min(rect.x1, text_right),
+            min(rect.y1, footer_top, text_bot),
+        )
+    else:
+        rect = fitz.Rect(
+            rect.x0,
+            max(rect.y0, header_bottom),
+            rect.x1,
+            min(rect.y1, footer_top),
+        )
+    if rect.y0 < rect.y1 and rect.x0 < rect.x1:
+        return rect
+    return None
+
+
+def _write_detections_sidecar(document: Document, output_dir: Path) -> int:
+    """Serialise all detections to ``output_dir/detections.json``.
+
+    :param document: Source document whose pages/detections are dumped.
+    :param output_dir: Directory to write the sidecar into; created if
+        necessary.
+    :returns: Number of detection rows written.
+    """
+    import json as _json
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    for page in document.pages:
+        for det in page.detections:
+            rows.append(
+                {
+                    "page_index": det.page_index,
+                    "label": det.label.name,
+                    "label_id": int(det.label),
+                    "confidence": round(det.confidence, 3),
+                    "bbox": [
+                        round(det.bbox.x1, 1),
+                        round(det.bbox.y1, 1),
+                        round(det.bbox.x2, 1),
+                        round(det.bbox.y2, 1),
+                    ],
+                    "page_number": page.page_number,
+                    "img_width": page.img_width,
+                    "img_height": page.img_height,
+                }
+            )
+    (output_dir / "detections.json").write_text(_json.dumps(rows))
+    return len(rows)
+
+
+def _write_pages_meta_sidecar(document: Document, output_dir: Path) -> None:
+    """Serialise column bounds and midpoint to ``output_dir/pages_meta.json``.
+
+    :param document: Source document.
+    :param output_dir: Directory to write the sidecar into; created if
+        necessary.
+    """
+    import json as _json
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[int, dict] = {}
+    for page in document.pages:
+        meta[page.index] = {
+            "col_left_x1": page.col_left_x1,
+            "col_left_x2": page.col_left_x2,
+            "col_right_x1": page.col_right_x1,
+            "col_right_x2": page.col_right_x2,
+            "midpoint": page.midpoint,
+        }
+    (output_dir / "pages_meta.json").write_text(_json.dumps(meta))
 
 
 def _mask_outside_opinion(
@@ -1868,64 +2121,8 @@ def split_opinions(
                         tight = _tighten_to_text(fitz_page, r, skip=False)
                         pn_rects.append(tight if tight is not None else r)
 
-                _page_redact_rects = []
-
-                def add_safe(rect: fitz.Rect, fill) -> None:
-                    """Add redaction annotation, clipping around page numbers."""
-                    if rect.is_empty:
-                        return
-                    for pn in pn_rects:
-                        if rect.intersects(pn):
-                            # Split: add parts above/below/left/right of PN
-                            # Top slice
-                            if rect.y0 < pn.y0:
-                                add_safe(
-                                    fitz.Rect(
-                                        rect.x0,
-                                        rect.y0,
-                                        rect.x1,
-                                        pn.y0,
-                                    ),
-                                    fill,
-                                )
-                            # Bottom slice
-                            if rect.y1 > pn.y1:
-                                add_safe(
-                                    fitz.Rect(
-                                        rect.x0,
-                                        pn.y1,
-                                        rect.x1,
-                                        rect.y1,
-                                    ),
-                                    fill,
-                                )
-                            # Left slice (middle band only)
-                            top = max(rect.y0, pn.y0)
-                            bot = min(rect.y1, pn.y1)
-                            if rect.x0 < pn.x0 and top < bot:
-                                add_safe(
-                                    fitz.Rect(
-                                        rect.x0,
-                                        top,
-                                        pn.x0,
-                                        bot,
-                                    ),
-                                    fill,
-                                )
-                            # Right slice (middle band only)
-                            if rect.x1 > pn.x1 and top < bot:
-                                add_safe(
-                                    fitz.Rect(
-                                        pn.x1,
-                                        top,
-                                        rect.x1,
-                                        bot,
-                                    ),
-                                    fill,
-                                )
-                            return
-                    _page_redact_rects.append((fitz.Rect(rect), fill))
-                    fitz_page.add_redact_annot(rect, fill=fill)
+                _page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
+                add_safe = _make_add_safe(fitz_page, pn_rects, collector=_page_redact_rects)
 
                 # White redact: content outside opinion (redacted + masked)
                 if is_first or is_last:
@@ -1942,29 +2139,13 @@ def split_opinions(
                 # Black redact: headnote zone (clipped to actual text)
                 header_bottom, footer_top = _margin_bounds(page)
                 for rect_page_idx, rect in headnote_rects:
-                    if rect_page_idx == src_idx:
-                        if not document.ocr_applied:
-                            tight = _tighten_to_text(fitz_page, rect)
-                            if tight is not None:
-                                rect = tight
-                            text_bot = _text_bottom(fitz_page, rect)
-                            text_left, text_right = _text_x_bounds(fitz_page, rect)
-                            rect = fitz.Rect(
-                                max(rect.x0, text_left),
-                                max(rect.y0, header_bottom),
-                                min(rect.x1, text_right),
-                                min(rect.y1, footer_top, text_bot),
-                            )
-                        else:
-                            # No reliable text layer, just clip to margins
-                            rect = fitz.Rect(
-                                rect.x0,
-                                max(rect.y0, header_bottom),
-                                rect.x1,
-                                min(rect.y1, footer_top),
-                            )
-                        if rect.y0 < rect.y1 and rect.x0 < rect.x1:
-                            add_safe(rect, (0, 0, 0))
+                    if rect_page_idx != src_idx:
+                        continue
+                    clipped = _clip_headnote_rect(
+                        fitz_page, rect, header_bottom, footer_top, document.ocr_applied
+                    )
+                    if clipped is not None:
+                        add_safe(clipped, (0, 0, 0))
 
                 # Per-detection redactions (skip black outside opinion bounds)
                 redact_labels = _REDACT_WHITE | _REDACT_BLACK

--- a/blackletter/scanner.py
+++ b/blackletter/scanner.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 DPI = 200
 CONFIDENCE_THRESHOLD = 0.20
+YOLO_BATCH = 4
 
 # Per-label minimum confidence for drawing/output (overrides default).
 LABEL_CONFIDENCE: dict[Label, float] = {
@@ -750,7 +751,6 @@ def scan(
 
     else:
         # Single-process path for small documents
-        BATCH_SIZE = 4
         mat = fitz.Matrix(DPI / 72, DPI / 72)
 
         def _render_batch(start: int, end: int):
@@ -801,8 +801,7 @@ def scan(
                 ]
                 pn_dets.sort(key=lambda d: d.confidence, reverse=True)
                 for pn_det in pn_dets:
-                    b = pn_det.bbox.to_pdf(page.scale_x, page.scale_y)
-                    rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+                    rect = pn_det.bbox.to_fitz_pdf_rect(page.scale_x, page.scale_y)
                     result = _extract_page_number(fitz_page, rect, hint=page_idx + first_page)
                     if result is not None:
                         page.page_number, page.page_number_end = result
@@ -810,7 +809,7 @@ def scan(
 
         from concurrent.futures import ThreadPoolExecutor
 
-        batches = [(s, min(s + BATCH_SIZE, total_pages)) for s in range(0, total_pages, BATCH_SIZE)]
+        batches = [(s, min(s + YOLO_BATCH, total_pages)) for s in range(0, total_pages, YOLO_BATCH)]
         with ThreadPoolExecutor(max_workers=1) as render_pool:
             next_future = render_pool.submit(_render_batch, *batches[0])
             for i, (batch_start, batch_end) in enumerate(batches):
@@ -1109,8 +1108,7 @@ def _draw_boxes(
     # First pass: compute all rects (tightened where possible)
     items: list[tuple[Detection, fitz.Rect]] = []
     for det in dets:
-        b = det.bbox.to_pdf(page.scale_x, page.scale_y)
-        rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+        rect = det.bbox.to_fitz_pdf_rect(page.scale_x, page.scale_y)
         if fitz_page is not None and det.label != Label.KEY_ICON:
             tight = _tighten_to_text(fitz_page, rect)
             if tight is not None:
@@ -1349,6 +1347,72 @@ def _build_opinions_data(
             }
         )
     return opinions_data
+
+
+def _opinion_page_bounds(
+    start_page: Page | None,
+    end_page: Page | None,
+    start_idx: int,
+    end_idx: int,
+    first_page: int,
+) -> tuple[int, int]:
+    """Infer the ``(first_num, last_num)`` pair for an opinion's filename.
+
+    When a page reports a numeric range (via ``page_number_end``), an
+    opinion starting on that page uses the **end** of the range and one
+    ending on that page uses the **start** of the range. Pages with no
+    OCR'd page number fall back to ``index + first_page``.
+
+    :param start_page: Page where the opinion's caption lives (``None``
+        if the page is missing from ``pages_by_index``).
+    :param end_page: Page where the opinion's key lives.
+    :param start_idx: 0-based page index of the opinion's first page.
+    :param end_idx: 0-based page index of the opinion's last page.
+    :param first_page: Logical first page number of the document.
+    :returns: ``(first_num, last_num)`` pair for the filename.
+    """
+    if start_page is not None and start_page.page_number_end:
+        first_num = start_page.page_number_end
+    elif start_page is not None and start_page.page_number:
+        first_num = start_page.page_number
+    else:
+        first_num = start_idx + first_page
+
+    if end_page is not None and end_page.page_number_end and end_page.page_number is not None:
+        last_num = end_page.page_number
+    elif end_page is not None and end_page.page_number is not None and end_page.page_number:
+        last_num = end_page.page_number
+    else:
+        last_num = end_idx + first_page
+
+    return first_num, last_num
+
+
+def _collect_page_number_rects(
+    page: Page,
+    fitz_page,
+    sx: float,
+    sy: float,
+) -> list[fitz.Rect]:
+    """Return PDF-point rects for every ``PAGE_NUMBER`` detection on ``page``.
+
+    Each rect is tightened to the actual page-number text (via
+    :func:`_tighten_to_text`) when possible, falling back to the raw
+    scaled bbox otherwise. Callers use the result to protect page-number
+    regions from being redacted (see :func:`_make_add_safe`).
+
+    :param page: Source page.
+    :param fitz_page: Corresponding PyMuPDF page for text-tightening.
+    :param sx: Horizontal pixel-to-PDF scale factor.
+    :param sy: Vertical pixel-to-PDF scale factor.
+    """
+    pn_rects: list[fitz.Rect] = []
+    for d in page.detections:
+        if d.label == Label.PAGE_NUMBER:
+            r = d.bbox.to_fitz_pdf_rect(sx, sy)
+            tight = _tighten_to_text(fitz_page, r, skip=False)
+            pn_rects.append(tight if tight is not None else r)
+    return pn_rects
 
 
 def _make_add_safe(
@@ -1882,8 +1946,7 @@ def _extract_opinion_footnotes(
     for det in deduped:
         page = pages_by_index[det.page_index]
         sx, sy = page.scale_x, page.scale_y
-        b = det.bbox.to_pdf(sx, sy)
-        full_clip = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+        full_clip = det.bbox.to_fitz_pdf_rect(sx, sy)
 
         if full_clip.is_empty:
             continue
@@ -2044,25 +2107,13 @@ def split_opinions(
     base_names: list[str] = []
     for idx, (caption, _key) in enumerate(opinions):
         start_idx, end_idx = page_ranges[idx]
-        start_page = pages_by_index.get(start_idx)
-        end_page = pages_by_index.get(end_idx)
-
-        # Opinion starting on a range page → use end number
-        if start_page and start_page.page_number_end:
-            first_num = start_page.page_number_end
-        elif start_page and start_page.page_number:
-            first_num = start_page.page_number
-        else:
-            first_num = start_idx + first_page
-
-        # Opinion ending on a range page → use first number
-        if end_page and end_page.page_number_end:
-            last_num = end_page.page_number
-        elif end_page and end_page.page_number:
-            last_num = end_page.page_number
-        else:
-            last_num = end_idx + first_page
-
+        first_num, last_num = _opinion_page_bounds(
+            pages_by_index.get(start_idx),
+            pages_by_index.get(end_idx),
+            start_idx,
+            end_idx,
+            first_page,
+        )
         base_names.append(f"{prefix}{first_num:04d}-{last_num:04d}")
 
     name_counts = Counter(base_names)
@@ -2147,13 +2198,7 @@ def split_opinions(
                 sx, sy = page.scale_x, page.scale_y
 
                 # Collect page number rects (these must never be redacted)
-                pn_rects = []
-                for d in page.detections:
-                    if d.label == Label.PAGE_NUMBER:
-                        b = d.bbox.to_pdf(sx, sy)
-                        r = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
-                        tight = _tighten_to_text(fitz_page, r, skip=False)
-                        pn_rects.append(tight if tight is not None else r)
+                pn_rects = _collect_page_number_rects(page, fitz_page, sx, sy)
 
                 _page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
                 add_safe = _make_add_safe(fitz_page, pn_rects, collector=_page_redact_rects)
@@ -2199,8 +2244,7 @@ def split_opinions(
                         sk = d.sort_key(mid)
                         if sk < cap_key or sk > key_key:
                             continue
-                    b = d.bbox.to_pdf(sx, sy)
-                    rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+                    rect = d.bbox.to_fitz_pdf_rect(sx, sy)
                     tight = _tighten_to_text(fitz_page, rect, skip=False)
                     if tight is not None:
                         rect = tight
@@ -2227,8 +2271,7 @@ def split_opinions(
                         CONFIDENCE_THRESHOLD,
                     ):
                         continue
-                    b = d.bbox.to_pdf(sx, sy)
-                    rect = fitz.Rect(b.x1, b.y1, b.x2, b.y2)
+                    rect = d.bbox.to_fitz_pdf_rect(sx, sy)
                     sk = d.sort_key(mid)
                     if sk < cap_key or sk > key_key:
                         # Outside opinion bounds, always white

--- a/blackletter/scanner.py
+++ b/blackletter/scanner.py
@@ -1496,6 +1496,40 @@ def _clip_headnote_rect(
     return None
 
 
+def _group_detections_by_page(
+    raw: list[dict],
+    include_page_number_end: bool = False,
+) -> dict[int, dict]:
+    """Bucket raw detection dicts by ``page_index``.
+
+    Each bucket collects ``page_number``, ``img_width``, ``img_height``
+    (with sensible defaults), and the raw ``detections`` list for that
+    page. When ``include_page_number_end`` is ``True`` the bucket also
+    records ``page_number_end``.
+
+    :param raw: Flat list of detection dicts (e.g. loaded from
+        ``detections.json``).
+    :param include_page_number_end: Whether to carry ``page_number_end``
+        from the first row seen for each page.
+    :returns: Mapping ``page_index -> bucket``.
+    """
+    pages_data: dict[int, dict] = {}
+    for entry in raw:
+        pi = entry["page_index"]
+        if pi not in pages_data:
+            bucket = {
+                "page_number": entry.get("page_number"),
+                "img_width": entry.get("img_width", 1),
+                "img_height": entry.get("img_height", 1),
+                "detections": [],
+            }
+            if include_page_number_end:
+                bucket["page_number_end"] = entry.get("page_number_end")
+            pages_data[pi] = bucket
+        pages_data[pi]["detections"].append(entry)
+    return pages_data
+
+
 def _write_detections_sidecar(document: Document, output_dir: Path) -> int:
     """Serialise all detections to ``output_dir/detections.json``.
 

--- a/blackletter/tasks.py
+++ b/blackletter/tasks.py
@@ -175,16 +175,15 @@ def yolo_scan_chunk(
     from ultralytics import YOLO
 
     from blackletter.models import Label
-    from blackletter.scanner import _safe_detect_columns, _extract_page_number, DPI
+    from blackletter.scanner import _safe_detect_columns, _extract_page_number, DPI, YOLO_BATCH
 
     model = YOLO(str(model_path))
     pdf = fitz.open(str(pdf_path))
     mat = fitz.Matrix(DPI / 72, DPI / 72)
-    BATCH = 4
     pages_data = []
 
-    for bs in range(page_start, page_end, BATCH):
-        be = min(bs + BATCH, page_end)
+    for bs in range(page_start, page_end, YOLO_BATCH):
+        be = min(bs + YOLO_BATCH, page_end)
         imgs = []
         meta = []
         for pi in range(bs, be):

--- a/blackletter/tasks.py
+++ b/blackletter/tasks.py
@@ -58,21 +58,12 @@ def bitonal_chunk(
     Returns:
         Path to the output chunk PDF.
     """
-    import io
-    import numpy as np
-    from PIL import Image
+    from blackletter.ocr import _render_bitonal_page
 
     src = fitz.open(str(src_path))
     out = fitz.open()
     for i in range(page_start, page_end):
-        page = src[i]
-        new_page = out.new_page(width=page.rect.width, height=page.rect.height)
-        pix = page.get_pixmap(dpi=dpi, colorspace=fitz.csGRAY)
-        gray = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
-        bw = Image.fromarray((gray > threshold).astype(np.uint8) * 255).convert("1")
-        buf = io.BytesIO()
-        bw.save(buf, format="TIFF", compression="group4")
-        new_page.insert_image(new_page.rect, stream=buf.getvalue())
+        _render_bitonal_page(src[i], out, dpi, threshold)
     out.save(str(dst_path), garbage=4, deflate=True)
     out.close()
     src.close()
@@ -122,8 +113,9 @@ def ocr_chunk(
     Returns:
         Path to OCR'd chunk PDF.
     """
-    import logging
     import tempfile
+
+    from blackletter.ocr import _silence_ocr_loggers
 
     # Extract pages
     src = fitz.open(str(src_path))
@@ -134,12 +126,7 @@ def ocr_chunk(
     chunk.close()
     src.close()
 
-    # Suppress noisy loggers
-    for name in ("pikepdf", "fontTools", "fontTools.subset", "fontTools.ttLib", "ocrmypdf"):
-        logging.getLogger(name).setLevel(logging.ERROR)
-    for _n in list(logging.root.manager.loggerDict):
-        if _n.startswith("ocrmypdf"):
-            logging.getLogger(_n).setLevel(logging.ERROR)
+    _silence_ocr_loggers()
 
     import ocrmypdf
 
@@ -184,13 +171,11 @@ def yolo_scan_chunk(
             index, pdf_width, pdf_height, img_width, img_height,
             cols, detections, page_number, page_number_end
     """
-    import cv2
-    import numpy as np
     from PIL import Image
     from ultralytics import YOLO
 
     from blackletter.models import Label
-    from blackletter.scanner import detect_columns, _extract_page_number, DPI
+    from blackletter.scanner import _safe_detect_columns, _extract_page_number, DPI
 
     model = YOLO(str(model_path))
     pdf = fitz.open(str(pdf_path))
@@ -207,11 +192,7 @@ def yolo_scan_chunk(
             pix = fp.get_pixmap(matrix=mat)
             img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
             imgs.append(img)
-            img_bgr = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
-            try:
-                lx1, lx2, rx1, rx2, mid = detect_columns(img_bgr)
-            except Exception:
-                lx1, lx2, rx1, rx2, mid = 0, 0, 0, 0, 0
+            cols = _safe_detect_columns(img)
             meta.append(
                 (
                     pi,
@@ -219,7 +200,7 @@ def yolo_scan_chunk(
                     fp.rect.height,
                     pix.width,
                     pix.height,
-                    (lx1, lx2, rx1, rx2, mid),
+                    cols,
                 )
             )
 
@@ -349,45 +330,13 @@ def merge_detections(
         ocr_applied=True,
     )
 
-    # Save detections.json
-    detections_data = []
-    for page in doc.pages:
-        for det in page.detections:
-            detections_data.append(
-                {
-                    "page_index": det.page_index,
-                    "label": det.label.name,
-                    "label_id": int(det.label),
-                    "confidence": round(det.confidence, 3),
-                    "bbox": [
-                        round(det.bbox.x1, 1),
-                        round(det.bbox.y1, 1),
-                        round(det.bbox.x2, 1),
-                        round(det.bbox.y2, 1),
-                    ],
-                    "page_number": page.page_number,
-                    "img_width": page.img_width,
-                    "img_height": page.img_height,
-                }
-            )
-    with open(output_dir / "detections.json", "w") as f:
-        json.dump(detections_data, f)
+    from blackletter.scanner import _write_detections_sidecar, _write_pages_meta_sidecar
 
-    # Save pages_meta.json
-    pages_meta = {}
-    for page in doc.pages:
-        pages_meta[page.index] = {
-            "col_left_x1": page.col_left_x1,
-            "col_left_x2": page.col_left_x2,
-            "col_right_x1": page.col_right_x1,
-            "col_right_x2": page.col_right_x2,
-            "midpoint": page.midpoint,
-        }
-    with open(output_dir / "pages_meta.json", "w") as f:
-        json.dump(pages_meta, f)
+    detections_count = _write_detections_sidecar(doc, output_dir)
+    _write_pages_meta_sidecar(doc, output_dir)
 
     return {
-        "detections_count": len(detections_data),
+        "detections_count": detections_count,
         "pages_count": len(pages),
     }
 
@@ -410,7 +359,7 @@ def pair_and_compute_rects(
         Dict with opinions_count, rects_count.
     """
     from blackletter.models import BBox, Detection, Document, Label, Page
-    from blackletter.scanner import _pair_opinions, _outside_opinion_rects
+    from blackletter.scanner import _pair_opinions, _build_opinions_data
     from blackletter.process import compute_redaction_rects
     from blackletter.margins import compute_margin_rects
 
@@ -489,51 +438,7 @@ def pair_and_compute_rects(
     # Save opinions.json with outside_rects
     pages_by_index = {p.index: p for p in document.pages}
     _src_pdf = fitz.open(str(pdf_path))
-    opinions_data = []
-    for caption, key in opinions:
-        outside_rects = []
-        for pi in range(caption.page_index, key.page_index + 1):
-            pg = pages_by_index[pi]
-            is_first = pi == caption.page_index
-            is_last = pi == key.page_index
-            pw = _src_pdf[pi].rect.width
-            for rect in _outside_opinion_rects(pg, pw, caption, key, is_first, is_last):
-                outside_rects.append(
-                    {
-                        "page_index": pi,
-                        "x0": round(rect.x0, 1),
-                        "y0": round(rect.y0, 1),
-                        "x1": round(rect.x1, 1),
-                        "y1": round(rect.y1, 1),
-                    }
-                )
-        has_image = any(
-            d.label == Label.IMAGE
-            for pi2 in range(caption.page_index, key.page_index + 1)
-            if pi2 in pages_by_index
-            for d in pages_by_index[pi2].detections
-        )
-        opinions_data.append(
-            {
-                "caption_page": caption.page_index,
-                "caption_bbox": [
-                    round(caption.bbox.x1, 1),
-                    round(caption.bbox.y1, 1),
-                    round(caption.bbox.x2, 1),
-                    round(caption.bbox.y2, 1),
-                ],
-                "key_page": key.page_index,
-                "key_bbox": [
-                    round(key.bbox.x1, 1),
-                    round(key.bbox.y1, 1),
-                    round(key.bbox.x2, 1),
-                    round(key.bbox.y2, 1),
-                ],
-                "page_count": key.page_index - caption.page_index + 1,
-                "outside_rects": outside_rects,
-                "has_image": has_image,
-            }
-        )
+    opinions_data = _build_opinions_data(opinions, pages_by_index, _src_pdf)
     _src_pdf.close()
     with open(output_dir / "opinions.json", "w") as f:
         json.dump(opinions_data, f)

--- a/blackletter/tasks.py
+++ b/blackletter/tasks.py
@@ -358,8 +358,12 @@ def pair_and_compute_rects(
     Returns:
         Dict with opinions_count, rects_count.
     """
-    from blackletter.models import BBox, Detection, Document, Label, Page
-    from blackletter.scanner import _pair_opinions, _build_opinions_data
+    from blackletter.models import Detection, Document, Page
+    from blackletter.scanner import (
+        _pair_opinions,
+        _build_opinions_data,
+        _group_detections_by_page,
+    )
     from blackletter.process import compute_redaction_rects
     from blackletter.margins import compute_margin_rects
 
@@ -381,17 +385,7 @@ def pair_and_compute_rects(
     }
     src_pdf.close()
 
-    pages_data = {}
-    for entry in raw:
-        pi = entry["page_index"]
-        if pi not in pages_data:
-            pages_data[pi] = {
-                "page_number": entry.get("page_number"),
-                "img_width": entry.get("img_width", 1),
-                "img_height": entry.get("img_height", 1),
-                "detections": [],
-            }
-        pages_data[pi]["detections"].append(entry)
+    pages_data = _group_detections_by_page(raw)
 
     pages = []
     for pi in sorted(pages_data.keys()):
@@ -412,15 +406,7 @@ def pair_and_compute_rects(
             midpoint=meta.get("midpoint", 0),
         )
         for d in pd["detections"]:
-            b = d.get("bbox", [0, 0, 1, 1])
-            page.detections.append(
-                Detection(
-                    bbox=BBox(x1=b[0], y1=b[1], x2=b[2], y2=b[3]),
-                    label=Label(d["label_id"]),
-                    confidence=d["confidence"],
-                    page_index=pi,
-                )
-            )
+            page.detections.append(Detection.from_raw_dict(d, pi, bbox_default=[0, 0, 1, 1]))
         pages.append(page)
 
     document = Document(

--- a/blackletter/validate.py
+++ b/blackletter/validate.py
@@ -425,7 +425,7 @@ def _structural_checks(file_path: str | Path) -> list[dict]:
                     "page_number": display_num,
                     "check_name": "orientation",
                     "severity": "info",
-                    "message": (f"Page {display_num} is {orientation}, differs from page 1."),
+                    "message": f"Page {display_num} is {orientation}, differs from page 1.",
                 }
             )
 

--- a/blackletter/validate.py
+++ b/blackletter/validate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import itertools
 import re
 from collections import Counter
+from collections.abc import Callable
 from pathlib import Path
 
 import fitz
@@ -20,7 +21,11 @@ RANGE_RE = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
 
 
 def _parse_expected_range(pdf_path: str | Path) -> tuple[int | None, int | None]:
-    """Extract expected first/last page numbers from filename."""
+    """Extract expected first/last page numbers from filename.
+
+    :param pdf_path: Path to the PDF file.
+    :returns: Tuple of (first_page, last_page), either may be ``None``.
+    """
     info = _infer_from_filename(Path(pdf_path))
     if info:
         return info.get("first_page"), info.get("last_page")
@@ -34,8 +39,10 @@ def _split_in_out_of_range(
 ) -> tuple[list[dict], dict[int, list[int]]]:
     """Separate OCR results into out-of-range and in-range buckets.
 
-    Returns:
-        (out_of_range_results, seen_nums_dict)
+    :param results: List of per-page OCR result dicts.
+    :param exp_start: Expected first page number, or ``None``.
+    :param exp_end: Expected last page number, or ``None``.
+    :returns: Tuple of (out_of_range_results, seen_nums_dict).
     """
     out_of_range: list[dict] = []
     seen_nums: dict[int, list[int]] = {}
@@ -68,9 +75,13 @@ def _auto_correct(
     If a consistent offset is detected (e.g. all bad readings are +800 from
     expected), apply the correction and return updated results.
 
-    Returns:
-        (updated_ocr_results, list_of_corrections)
-        Each correction is (pdf_page, old_value, new_value).
+    :param ocr_results: Full list of per-page OCR result dicts.
+    :param out_of_range: Subset of results whose detected numbers fall
+        outside the expected range.
+    :param seen_nums: Mapping of detected page number to list of PDF pages
+        where it was seen.
+    :returns: Tuple of (updated_ocr_results, list_of_corrections) where
+        each correction is (pdf_page, old_value, new_value).
     """
     corrections: list[tuple[int, str, str]] = []
     if not out_of_range or not seen_nums:
@@ -126,9 +137,17 @@ def _build_issues(
 ) -> dict:
     """Convert raw analysis into issues, page_map, and missing_pages.
 
-    This is the core validation logic — sequence issues become structured
+    This is the core validation logic. Sequence issues become structured
     issue dicts, large gaps are collapsed into warnings, and a page_map
     is built for viewer display.
+
+    :param analysis: Dict of filtered OCR analysis data (results,
+        seq_issues, duplicates, missing_pages, etc.).
+    :param pdf_page_count: Total number of pages in the PDF.
+    :param exp_start: Expected first page number, or ``None``.
+    :param exp_end: Expected last page number, or ``None``.
+    :returns: Dict with keys ``page_count``, ``page_map``,
+        ``missing_pages``, ``issues``, and ``ocr_results``.
     """
     issues: list[dict] = []
 
@@ -165,7 +184,7 @@ def _build_issues(
                         "severity": "warning",
                         "message": (
                             f"Large jump from page {prev_num} to {num} ({len(gap)} pages) "
-                            f"— likely an OCR misread. Correct the page number and "
+                            f", likely an OCR misread. Correct the page number and "
                             f"recalculate."
                         ),
                     }
@@ -220,7 +239,7 @@ def _build_issues(
                 "severity": "warning",
                 "message": (
                     f"PDF page {r['pdf_page']} detected as '{r['detected']}' which is "
-                    f"outside the expected page range — likely a stray number."
+                    f"outside the expected page range, likely a stray number."
                 ),
             }
         )
@@ -265,7 +284,7 @@ def _build_issues(
                     "severity": "warning",
                     "message": (
                         f"PDF page {r['pdf_page']} covers page range "
-                        f"{r['detected']} — verify this is expected."
+                        f"{r['detected']}. Verify this is expected."
                     ),
                 }
             )
@@ -288,7 +307,7 @@ def _build_issues(
                             "severity": "warning",
                             "message": (
                                 f"Large gap: pages {run[0]}–{run[-1]} ({len(run)} pages) "
-                                f"not found — likely an OCR misread rather than genuinely "
+                                f"not found, likely an OCR misread rather than genuinely "
                                 f"missing pages."
                             ),
                         }
@@ -370,7 +389,11 @@ def _build_issues(
 
 
 def _structural_checks(file_path: str | Path) -> list[dict]:
-    """Quick PyMuPDF checks for blank pages and orientation changes."""
+    """Quick PyMuPDF checks for blank pages and orientation changes.
+
+    :param file_path: Path to the PDF file.
+    :returns: List of issue dicts for any blank pages or orientation changes.
+    """
     doc = fitz.open(str(file_path))
     issues: list[dict] = []
     first_is_landscape = None
@@ -416,7 +439,7 @@ def validate(
     exp_start: int | None = None,
     exp_end: int | None = None,
     auto_correct: bool = True,
-    progress_callback=None,
+    progress_callback: Callable[[int, int, str], None] | None = None,
     model: str | Path | None = None,
     num_workers: int | None = None,
 ) -> dict:
@@ -426,22 +449,19 @@ def validate(
     missing pages, duplicates, gaps, and numbering errors. Optionally
     auto-corrects consistent OCR misreadings.
 
-    Args:
-        pdf_path: Path to the PDF file.
-        exp_start: Expected first page number (inferred from filename if omitted).
-        exp_end: Expected last page number (inferred from filename if omitted).
-        auto_correct: Attempt to fix consistent out-of-range OCR readings.
-        progress_callback: Optional callable(current, total, message).
-        model: Path to YOLO model for page number detection.
-
-    Returns:
-        Dict with keys:
-            page_count: Total pages in PDF.
-            page_map: Ordered list of page entries for viewer display.
-            missing_pages: List of missing logical page numbers.
-            issues: List of issue dicts (page_number, check_name, severity, message).
-            ocr_results: Raw per-page OCR results.
-            auto_corrections: List of (pdf_page, old_value, new_value) if any.
+    :param pdf_path: Path to the PDF file.
+    :param exp_start: Expected first page number (inferred from filename
+        if omitted).
+    :param exp_end: Expected last page number (inferred from filename
+        if omitted).
+    :param auto_correct: Attempt to fix consistent out-of-range OCR
+        readings.
+    :param progress_callback: Optional callable(current, total, message).
+    :param model: Path to YOLO model for page number detection.
+    :param num_workers: Number of parallel workers for OCR.
+    :returns: Dict with keys ``page_count``, ``page_map``,
+        ``missing_pages``, ``issues``, ``ocr_results``, and
+        ``auto_corrections``.
     """
     pdf_path = str(pdf_path)
 
@@ -564,7 +584,7 @@ def validate(
                 "severity": "warning",
                 "message": (
                     f"PDF page {pdf_page}: OCR read '{old_val}', auto-corrected "
-                    f"to '{new_val}' based on surrounding page numbers — verify "
+                    f"to '{new_val}' based on surrounding page numbers. Verify "
                     f"this is correct."
                 ),
             }


### PR DESCRIPTION
- Add rST docstrings (:param: / :returns:) across api, margins, models, analyze, scanner, and validate
- Add Callable type hints for progress_callback params
- Fix resource leak in ocr() (fitz.open never closed)
- Fix stale usage examples in api.py module docstring
- Remove dead code: unused list[dict] type in build_redacted, commented-out block in pair()
- Remove unnecessary import aliases (_re, _Counter, _fitz, _I)
- Replace em dashes in comments and strings project-wide
- Add Coming up section to CHANGES.md