### PR TITLE
feat(api): add ensure_weights helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ The following changes are not yet released, but are code complete:
 - Replace per-opinion detection scanning with a single pre-sorted list and bisect slicing in `_build_full_redacted` (#37)
 - Eliminate temp PNG file writes during OCR crop processing, reducing I/O overhead and preventing leaked files in `/tmp` on crashes (#38)
 - Add check changelog action (#40)
+- Add new helper to download weights (#42)
 
 ## Current
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ The following changes are not yet released, but are code complete:
 - Eliminate temp PNG file writes during OCR crop processing, reducing I/O overhead and preventing leaked files in `/tmp` on crashes (#38)
 - Add check changelog action (#40)
 - Add new helper to download weights (#42)
+- Consolidate model download logic through `ensure_weights`: `detect()` now downloads missing weights instead of silently skipping, and `cli.py` and `analyze.py` no longer duplicate the Hugging Face download code (#42)
 
 ## Current
 

--- a/blackletter/analyze.py
+++ b/blackletter/analyze.py
@@ -356,17 +356,12 @@ def _process_page(args: tuple) -> dict:
     if not hasattr(_process_page, "_yolo"):
         from ultralytics import YOLO
 
-        model_path = Path(model_path)
-        if not model_path.exists():
-            from huggingface_hub import hf_hub_download
+        from blackletter.api import ensure_weights
 
-            model_path.parent.mkdir(parents=True, exist_ok=True)
-            downloaded = hf_hub_download(
-                repo_id="flooie/blackletter-large",
-                filename=model_path.name,
-                local_dir=model_path.parent,
-            )
-            model_path = Path(downloaded)
+        model_path = Path(model_path)
+        if not model_path.is_file():
+            resolved = ensure_weights([model_path.stem])
+            model_path = resolved[model_path.stem]
         _process_page._yolo = YOLO(str(model_path))
     if not hasattr(_process_page, "_glm"):
         # Lazy-load GLM-OCR: don't load the model upfront, only when needed
@@ -555,27 +550,16 @@ def analyze_pdf(
     """
     import fitz
 
+    from blackletter.api import ensure_weights
+
     pdf_path = str(pdf_path)
     if model is None:
         model = DEFAULT_ANALYZE_MODEL
 
-    # Auto-download model from Hugging Face if not present
     model = Path(model)
-    if not model.exists():
-        try:
-            from huggingface_hub import hf_hub_download
-
-            print(f"  Downloading {model.name} from Hugging Face...", flush=True)
-            downloaded = hf_hub_download(
-                repo_id="flooie/blackletter-large",
-                filename=model.name,
-                local_dir=model.parent,
-            )
-            model = Path(downloaded)
-        except Exception as e:
-            raise FileNotFoundError(
-                f"Model not found at {model} and could not be downloaded: {e}"
-            ) from e
+    if not model.is_file():
+        resolved = ensure_weights([model.stem])
+        model = resolved[model.stem]
 
     if num_workers is None:
         num_workers = min(4, cpu_count())

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -4,8 +4,9 @@ Each function is one discrete step. Call only what you need.
 All functions work with file paths and return file paths or data.
 
 Usage:
-    from blackletter.api import bitonal, ocr, detect, pair, compute_rects, build_redacted, split_opinions
+    from blackletter.api import ensure_weights, bitonal, ocr, detect, pair, compute_rects, build_redacted, split_opinions
 
+    ensure_weights(["large"])  # download large.pt from HF if absent
     bitonal_pdf = bitonal(source_pdf, output_dir)
     ocr_pdf = ocr(bitonal_pdf, output_dir)
     detections = detect(bitonal_pdf, output_dir, models=["medium", "large"])
@@ -24,6 +25,75 @@ from collections.abc import Callable
 from pathlib import Path
 
 import fitz
+
+
+# Hugging Face sources for weights not bundled in the package.
+# ``small`` and ``medium`` ship inside ``blackletter/weights/`` via
+# ``package-data`` in ``pyproject.toml``; ``large`` is too big for
+# PyPI and is downloaded on demand.
+_HF_WEIGHTS: dict[str, tuple[str, str]] = {
+    "large": ("flooie/blackletter-large", "large.pt"),
+}
+
+
+def ensure_weights(models: list[str] | None = None) -> dict[str, Path]:
+    """Ensure named YOLO weights exist under ``blackletter/weights/``.
+
+    For bundled weights (``small``, ``medium``), this simply resolves
+    the path. For weights sourced from Hugging Face (currently only
+    ``large``), downloads them to the package weights directory if
+    they are not already present. Safe to call repeatedly; a noop when
+    every requested weight is already on disk.
+
+    Call this before :func:`detect` if you want to guarantee that a
+    weight is available rather than relying on :func:`detect`'s
+    silent-skip behaviour for missing weights.
+
+    :param models: Model size names to ensure (e.g. ``["large"]``).
+        Defaults to all three: ``small``, ``medium``, ``large``.
+    :returns: Mapping from model name to its resolved path on disk.
+    :rtype: dict[str, Path]
+    :raises RuntimeError: If ``huggingface_hub`` is not installed but
+        a download is required. Install with
+        ``pip install blackletter[analyze]``.
+    :raises FileNotFoundError: If a requested weight is missing from
+        the installation and has no Hugging Face source.
+    """
+    weights_dir = Path(__file__).resolve().parent / "weights"
+    weights_dir.mkdir(parents=True, exist_ok=True)
+
+    if models is None:
+        models = ["small", "medium", "large"]
+
+    resolved: dict[str, Path] = {}
+    for name in models:
+        path = weights_dir / f"{name}.pt"
+        if path.is_file():
+            resolved[name] = path
+            continue
+
+        source = _HF_WEIGHTS.get(name)
+        if source is None:
+            raise FileNotFoundError(f"Weight {path} is missing and has no Hugging Face source.")
+
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise RuntimeError(
+                f"huggingface_hub is required to download {name}.pt. "
+                "Install with `pip install blackletter[analyze]`."
+            ) from exc
+
+        repo_id, filename = source
+        print(f"  Downloading {filename} from {repo_id}...", flush=True)
+        downloaded = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            local_dir=str(weights_dir),
+        )
+        resolved[name] = Path(downloaded)
+
+    return resolved
 
 
 def bitonal(

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -211,12 +211,11 @@ def detect(
 
     pdf_path = Path(pdf_path)
     output_dir = Path(output_dir)
-    models_dir = Path(__file__).parent / "weights"
 
     if models is None:
         models = ["small", "medium", "large"]
 
-    model_map = {"small": "small.pt", "medium": "medium.pt", "large": "large.pt"}
+    resolved = ensure_weights(models)
 
     from blackletter.scanner import DPI, YOLO_BATCH
 
@@ -226,11 +225,7 @@ def detect(
 
     all_raw = []
     for model_name in models:
-        model_file = models_dir / model_map.get(model_name, f"{model_name}.pt")
-        if not model_file.exists():
-            print(f"  Model {model_file} not found, skipping", flush=True)
-            continue
-
+        model_file = resolved[model_name]
         model = YOLO(str(model_file))
         print(f"  Detecting with {model_name}...", flush=True)
         t0 = time.time()

--- a/blackletter/cli.py
+++ b/blackletter/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ultralytics import YOLO
 
+from blackletter.api import ensure_weights
 from blackletter.models import Label
 from blackletter.scanner import (
     scan,
@@ -22,28 +23,16 @@ DEFAULT_MODEL = Path(__file__).resolve().parent / "weights" / "small.pt"
 MEDIUM_MODEL = Path(__file__).resolve().parent / "weights" / "medium.pt"
 LARGE_MODEL = Path(__file__).resolve().parent / "weights" / "large.pt"
 
-# Hugging Face repo for models not bundled in the package
-_HF_SOURCES = {
-    LARGE_MODEL: ("flooie/blackletter-large", "large.pt"),
-}
-
 
 def _ensure_model(path: Path) -> None:
-    """Download model from Hugging Face if not present locally."""
-    if path.exists():
+    """Ensure the model at ``path`` is present; download bundled weights if missing."""
+    if path.is_file():
         return
-    if path not in _HF_SOURCES:
-        print(f"Model not found: {path}")
-        sys.exit(1)
-    repo_id, filename = _HF_SOURCES[path]
-    print(f"Model not found locally — downloading {filename} from {repo_id}...")
     try:
-        from huggingface_hub import hf_hub_download
-    except ImportError:
-        print("huggingface_hub is required to download models. Run: pip install huggingface_hub")
+        ensure_weights([path.stem])
+    except (RuntimeError, FileNotFoundError) as exc:
+        print(str(exc))
         sys.exit(1)
-    hf_hub_download(repo_id=repo_id, filename=filename, local_dir=path.parent)
-    print(f"Downloaded to {path}")
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_ensure_weights.py
+++ b/tests/test_ensure_weights.py
@@ -1,0 +1,113 @@
+"""Tests for ``blackletter.api.ensure_weights``.
+
+``small`` and ``medium`` are bundled in the package, so we exercise
+them directly. ``large`` is normally pulled from Hugging Face, so the
+download is mocked to avoid network access.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from blackletter import api
+
+
+PACKAGE_WEIGHTS_DIR = Path(api.__file__).resolve().parent / "weights"
+
+
+# ── Bundled weights (small, medium) ──────────────────────────────────────
+
+
+class TestBundledWeights:
+    def test_small_and_medium_resolve_to_bundled_files(self):
+        """``small`` and ``medium`` ship in-package and just resolve."""
+        resolved = api.ensure_weights(["small", "medium"])
+
+        assert set(resolved) == {"small", "medium"}
+        assert resolved["small"] == PACKAGE_WEIGHTS_DIR / "small.pt"
+        assert resolved["medium"] == PACKAGE_WEIGHTS_DIR / "medium.pt"
+        assert resolved["small"].is_file()
+        assert resolved["medium"].is_file()
+
+    def test_does_not_touch_huggingface_hub_for_bundled(self):
+        """No download attempt when bundled weights exist."""
+        fake_hf = MagicMock()
+        fake_hf.hf_hub_download.side_effect = AssertionError(
+            "should not be called for bundled weights"
+        )
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
+            api.ensure_weights(["small", "medium"])
+
+        fake_hf.hf_hub_download.assert_not_called()
+
+
+# ── Large weight (mocked) ────────────────────────────────────────────────
+
+
+class TestLargeWeightMocked:
+    def test_large_noop_when_already_present(self, tmp_path, monkeypatch):
+        """If ``large.pt`` exists locally, no download is attempted."""
+        fake_pkg = tmp_path / "blackletter"
+        fake_pkg.mkdir()
+        (fake_pkg / "api.py").touch()
+        (fake_pkg / "weights").mkdir()
+        (fake_pkg / "weights" / "large.pt").write_bytes(b"stub")
+        monkeypatch.setattr(api, "__file__", str(fake_pkg / "api.py"))
+
+        fake_hf = MagicMock()
+        fake_hf.hf_hub_download.side_effect = AssertionError("should not download when file exists")
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
+            resolved = api.ensure_weights(["large"])
+
+        assert resolved["large"] == fake_pkg / "weights" / "large.pt"
+        fake_hf.hf_hub_download.assert_not_called()
+
+    def test_large_downloads_when_missing(self, tmp_path, monkeypatch):
+        """Missing ``large.pt`` triggers a HF download call."""
+        fake_pkg = tmp_path / "blackletter"
+        fake_pkg.mkdir()
+        (fake_pkg / "api.py").touch()
+        weights_dir = fake_pkg / "weights"
+        # Intentionally do NOT create the weights dir or large.pt.
+        monkeypatch.setattr(api, "__file__", str(fake_pkg / "api.py"))
+
+        downloaded_path = weights_dir / "large.pt"
+
+        def fake_download(*, repo_id, filename, local_dir):
+            assert repo_id == "flooie/blackletter-large"
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
+            target = Path(local_dir) / filename
+            target.write_bytes(b"downloaded-stub")
+            return str(target)
+
+        fake_hf = MagicMock()
+        fake_hf.hf_hub_download.side_effect = fake_download
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
+            resolved = api.ensure_weights(["large"])
+
+        fake_hf.hf_hub_download.assert_called_once_with(
+            repo_id="flooie/blackletter-large",
+            filename="large.pt",
+            local_dir=str(weights_dir),
+        )
+        assert resolved["large"] == downloaded_path
+        assert downloaded_path.is_file()
+
+
+# ── Error cases ──────────────────────────────────────────────────────────
+
+
+class TestErrors:
+    def test_unknown_weight_without_hf_source_raises(self, tmp_path, monkeypatch):
+        """A missing weight with no HF mapping raises ``FileNotFoundError``."""
+        fake_pkg = tmp_path / "blackletter"
+        fake_pkg.mkdir()
+        (fake_pkg / "api.py").touch()
+        monkeypatch.setattr(api, "__file__", str(fake_pkg / "api.py"))
+
+        with pytest.raises(FileNotFoundError, match="no Hugging Face source"):
+            api.ensure_weights(["nonexistent"])

--- a/tests/test_ensure_weights.py
+++ b/tests/test_ensure_weights.py
@@ -111,3 +111,21 @@ class TestErrors:
 
         with pytest.raises(FileNotFoundError, match="no Hugging Face source"):
             api.ensure_weights(["nonexistent"])
+
+
+# ── detect() integration ─────────────────────────────────────────────────
+
+
+class TestDetectIntegration:
+    def test_detect_raises_for_unknown_model_instead_of_skipping(self, tmp_path):
+        """``detect`` should raise for unknown model names, not silently skip.
+
+        ``ensure_weights`` runs up front in ``detect``, so the PDF is
+        never opened and we can pass a non-existent path.
+        """
+        with pytest.raises(FileNotFoundError, match="no Hugging Face source"):
+            api.detect(
+                pdf_path=tmp_path / "fake.pdf",
+                output_dir=tmp_path,
+                models=["nonexistent"],
+            )


### PR DESCRIPTION
Provide a public entry point for resolving bundled weights and downloading large.pt from Hugging Face on demand. 

Callers can now call `ensure_weights(["large"])` before `detect()` instead of relying on detect()'s silent-skip for missing weights. 