### PR TITLE
perf: lazy-load ultralytics so package imports don't pull in torch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+- Lazy-load `ultralytics`/`torch` so importing `blackletter` (or any submodule) no longer pulls in the GPU stack. CPU-only consumers (e.g. scanning daemons running with RunPod) save ~500 MB to 1 GB of resident memory; YOLO-using code paths are unchanged (#44)
+
 ## Current
 
 0.0.9 (2026-04-29)

--- a/blackletter/__init__.py
+++ b/blackletter/__init__.py
@@ -1,20 +1,37 @@
-from blackletter.process import process, generate_files
-from blackletter.validate import validate
-from blackletter.tasks import (
-    split_page_ranges,
-    bitonal_chunk,
-    ocr_chunk,
-    yolo_scan_chunk,
-    merge_pdfs,
-    merge_detections,
-    pair_and_compute_rects,
-)
+"""Blackletter package.
+
+Public API is exposed lazily via PEP 562 ``__getattr__`` so that
+``import blackletter`` (or ``import blackletter.models``) does not
+transitively load ``blackletter.process`` and pull in
+``ultralytics``/``torch``. Consumers that don't need YOLO (the
+scanning daemon's idle loop, or any code path that only touches
+``blackletter.api`` / ``blackletter.models``) avoid hundreds of MB of
+GPU library state until something actually calls into a YOLO-using
+path.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from blackletter.process import generate_files, process
+    from blackletter.tasks import (
+        bitonal_chunk,
+        merge_detections,
+        merge_pdfs,
+        ocr_chunk,
+        pair_and_compute_rects,
+        split_page_ranges,
+        yolo_scan_chunk,
+    )
+    from blackletter.validate import validate
 
 __all__ = [
     "process",
     "generate_files",
     "validate",
-    # Chunk-able task functions for celery
     "split_page_ranges",
     "bitonal_chunk",
     "ocr_chunk",
@@ -23,3 +40,44 @@ __all__ = [
     "merge_detections",
     "pair_and_compute_rects",
 ]
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "process": ("blackletter.process", "process"),
+    "generate_files": ("blackletter.process", "generate_files"),
+    "validate": ("blackletter.validate", "validate"),
+    "split_page_ranges": ("blackletter.tasks", "split_page_ranges"),
+    "bitonal_chunk": ("blackletter.tasks", "bitonal_chunk"),
+    "ocr_chunk": ("blackletter.tasks", "ocr_chunk"),
+    "yolo_scan_chunk": ("blackletter.tasks", "yolo_scan_chunk"),
+    "merge_pdfs": ("blackletter.tasks", "merge_pdfs"),
+    "merge_detections": ("blackletter.tasks", "merge_detections"),
+    "pair_and_compute_rects": ("blackletter.tasks", "pair_and_compute_rects"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public exports on first access.
+
+    :param name: Attribute being accessed on the package.
+    :returns: The resolved object, cached in ``globals()`` for
+        subsequent accesses.
+    :rtype: Any
+    :raises AttributeError: When ``name`` isn't part of the public API.
+    """
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'blackletter' has no attribute {name!r}")
+    module_name, attr = target
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Expose lazy exports to ``dir(blackletter)`` and tooling.
+
+    :returns: Sorted list of public names plus already-resolved globals.
+    :rtype: list[str]
+    """
+    return sorted(set(__all__) | set(globals().keys()))

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 
 import fitz
-from ultralytics import YOLO
 
 from blackletter.models import BBox, Detection, Label
 from blackletter.refine import refine_headnote_rects
@@ -1035,6 +1034,8 @@ def cmd_process(args: argparse.Namespace) -> None:
 
     import time as _time
 
+    from ultralytics import YOLO
+
     _t_total = _time.time()
 
     model = YOLO(str(args.model))
@@ -1382,6 +1383,8 @@ def reprocess_section(
         redacted_paths, unredacted_paths.
     """
     import tempfile
+
+    from ultralytics import YOLO
 
     ocr_pdf_path = Path(ocr_pdf_path)
     output_dir = Path(output_dir)

--- a/blackletter/scanner.py
+++ b/blackletter/scanner.py
@@ -9,14 +9,17 @@ import subprocess
 import tempfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cv2
 import fitz
 import numpy as np
 from PIL import Image
-from ultralytics import YOLO
 
 from blackletter.models import BBox, Detection, Document, Label, Page
+
+if TYPE_CHECKING:
+    from ultralytics import YOLO
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,109 @@
+"""Regression tests for lazy ultralytics loading.
+
+The blackletter package is consumed by CPU-only callers (e.g. the
+scanning daemon when ``RUNPOD_ENABLED`` is true) that should not be
+forced to load ``ultralytics`` and ``torch`` at import time. These
+tests run each check in a fresh subprocess so a previous test's
+imports can't pollute ``sys.modules`` and mask a regression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run(script: str) -> str:
+    """Execute ``script`` in a fresh Python subprocess.
+
+    :param script: Python source to run.
+    :returns: Captured stdout.
+    :rtype: str
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestLazyUltralyticsImport:
+    """Importing blackletter must not transitively load ultralytics."""
+
+    def test_import_package_does_not_load_ultralytics(self):
+        out = _run(
+            """
+            import sys
+            import blackletter  # noqa: F401
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_import_models_does_not_load_ultralytics(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.models  # noqa: F401
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_import_api_does_not_load_ultralytics(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.api  # noqa: F401
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_import_scanner_does_not_load_ultralytics(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.scanner  # noqa: F401
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_import_process_does_not_load_ultralytics(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.process  # noqa: F401
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_lazy_export_resolves_without_loading_ultralytics(self):
+        """Accessing ``blackletter.validate`` should not pull in YOLO."""
+        out = _run(
+            """
+            import sys
+            import blackletter
+            fn = blackletter.validate
+            assert callable(fn)
+            print('ultralytics' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        out = _run(
+            """
+            import blackletter
+            try:
+                blackletter.does_not_exist
+            except AttributeError as exc:
+                print('AttributeError')
+            """
+        )
+        assert out == "AttributeError"


### PR DESCRIPTION
## The problem

Doing `import blackletter` (or `import blackletter.models`, `import blackletter.api`, etc.) was eagerly loading `ultralytics` and `torch` into memory. The reason: `blackletter/__init__.py` did `from blackletter.process import process, generate_files` at the top, and `process.py` had `from ultralytics import YOLO` at its top. So every consumer of the package paid the cost of loading the full GPU stack, including consumers that never call YOLO.

## What we win

- **Production daemons (RunPod mode):** the scanning daemon never calls a YOLO entry point in production. YOLO and PaddleOCR run on RunPod workers; the daemon only does CPU work (bitonal, OCR, pairing, redaction-rect math, file generation). Today the daemon still loads ultralytics + torch at boot anyway, costing roughly 500 MB to 1 GB of resident memory for the entire pod lifetime. After this change the daemon never imports ultralytics. On AWS, where memory is billed per GB-month per pod, that's a real saving and lets the daemon fit on a smaller instance class.
- **Local dev / CLI / `RUNPOD_ENABLED=false`:** ultralytics still loads, but only when the first scan actually starts (when `bl_detect` or `cmd_process` is called). Daemon boot is faster and idle dev daemons stay light. Peak memory during a scan is unchanged because YOLO still has to be in memory to run.
- **Other library consumers:** anyone importing `blackletter.models`, `blackletter.api`, etc. for non-GPU work (validation, pure data classes, rendering helpers) no longer pays for torch.

## Why this approach

The fix lives at the root in blackletter rather than being patched into each consumer. Two structural problems had to change:

1. The package `__init__.py` eagerly imported `process` and `tasks`. Even running `import blackletter.models` first executes `__init__.py`, which is why a leaf module with no GPU code was still triggering ultralytics. Switching to PEP 562 lazy `__getattr__` means the public exports (`blackletter.process`, `blackletter.validate`, etc.) still work, but they only resolve when someone actually accesses them.
2. `process.py` and `scanner.py` had `from ultralytics import YOLO` at module top. These are the only modules in the package with that pattern. The actual `YOLO(...)` calls live in `cmd_process`, `reprocess_section`, and the CLI; moving the import down next to the call sites costs nothing because Python caches imports after the first call.

`scanner.py` only references `YOLO` as a type annotation on the `scan()` parameter, so a `TYPE_CHECKING`-only import is enough there. `from __future__ import annotations` was already in place.

## Summary of changes

- `blackletter/__init__.py`: replaced eager `from blackletter.process import ...` and `from blackletter.tasks import ...` with PEP 562 `__getattr__` lazy resolution. Public API surface is preserved (`from blackletter import process`, `from blackletter import validate`, etc. all still work). A `TYPE_CHECKING` block keeps Pyright happy.
- `blackletter/process.py`: removed top-level `from ultralytics import YOLO`. Re-imported lazily inside `cmd_process` and `reprocess_section`, the only functions that instantiate `YOLO(...)`.
- `blackletter/scanner.py`: top-level YOLO import demoted to `TYPE_CHECKING`-only. No runtime use, just a type hint.
- `tests/test_lazy_imports.py` (new): seven subprocess-isolated tests that import each blackletter module in a fresh interpreter and assert `ultralytics` is not in `sys.modules` afterward, locking the property in.

Full suite: 83 passed, 13 skipped (skips unchanged from main, they need fixtures not in the checkout).

Paired with @quevon24 and [Claude Code](https://claude.com/claude-code)