### PR TITLE
fix: close fitz.Document via context manager to prevent leaks on exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+- Close every `fitz.Document` via `with fitz.open(...)` in `margins.py`, `api.py`, and `process.py` so exceptions no longer leak the open (mmap-backed) Document, fixing the runaway memory growth seen in downstream scanning web pods
+
 ## Current
 
 0.0.10 (2026-05-14)

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -120,20 +120,17 @@ def bitonal(
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "bitonal.pdf"
 
-    src = fitz.open(str(pdf_path))
-    out = fitz.open()
-    total = src.page_count
+    with fitz.open(str(pdf_path)) as src, fitz.open() as out:
+        total = src.page_count
 
-    for i in range(total):
-        _render_bitonal_page(src[i], out, dpi, threshold)
-        if progress_callback and ((i + 1) % 10 == 0 or i == total - 1):
-            progress_callback(i + 1, total, f"Bitonal: {i + 1}/{total} pages")
-        if (i + 1) % 50 == 0 or i == total - 1:
-            print(f"  Bitonal {i + 1}/{total}", flush=True)
+        for i in range(total):
+            _render_bitonal_page(src[i], out, dpi, threshold)
+            if progress_callback and ((i + 1) % 10 == 0 or i == total - 1):
+                progress_callback(i + 1, total, f"Bitonal: {i + 1}/{total} pages")
+            if (i + 1) % 50 == 0 or i == total - 1:
+                print(f"  Bitonal {i + 1}/{total}", flush=True)
 
-    out.save(str(output_path), garbage=4, deflate=True)
-    out.close()
-    src.close()
+        out.save(str(output_path), garbage=4, deflate=True)
     print(f"  Saved bitonal.pdf ({output_path.stat().st_size / 1024 / 1024:.1f} MB)", flush=True)
     return output_path
 
@@ -219,53 +216,51 @@ def detect(
 
     from blackletter.scanner import DPI, YOLO_BATCH
 
-    pdf = fitz.open(str(pdf_path))
     mat = fitz.Matrix(DPI / 72, DPI / 72)
-    total = pdf.page_count
 
     all_raw = []
-    for model_name in models:
-        model_file = resolved[model_name]
-        model = YOLO(str(model_file))
-        print(f"  Detecting with {model_name}...", flush=True)
-        t0 = time.time()
+    with fitz.open(str(pdf_path)) as pdf:
+        total = pdf.page_count
+        for model_name in models:
+            model_file = resolved[model_name]
+            model = YOLO(str(model_file))
+            print(f"  Detecting with {model_name}...", flush=True)
+            t0 = time.time()
 
-        for bs in range(0, total, YOLO_BATCH):
-            be = min(bs + YOLO_BATCH, total)
-            imgs = []
-            metas = []
-            for i in range(bs, be):
-                pix = pdf[i].get_pixmap(matrix=mat)
-                imgs.append(Image.frombytes("RGB", (pix.width, pix.height), pix.samples))
-                metas.append({"index": i, "img_width": pix.width, "img_height": pix.height})
+            for bs in range(0, total, YOLO_BATCH):
+                be = min(bs + YOLO_BATCH, total)
+                imgs = []
+                metas = []
+                for i in range(bs, be):
+                    pix = pdf[i].get_pixmap(matrix=mat)
+                    imgs.append(Image.frombytes("RGB", (pix.width, pix.height), pix.samples))
+                    metas.append({"index": i, "img_width": pix.width, "img_height": pix.height})
 
-            results = model(imgs, conf=confidence, verbose=False)
-            for j, res in enumerate(results):
-                pm = metas[j]
-                for box in res.boxes:
-                    class_id = int(box.cls[0].item())
-                    try:
-                        label_name = Label(class_id).name
-                    except ValueError:
-                        continue
-                    all_raw.append(
-                        {
-                            "page_index": pm["index"],
-                            "label": label_name,
-                            "label_id": class_id,
-                            "confidence": round(float(box.conf[0].item()), 3),
-                            "bbox": [round(v, 1) for v in box.xyxy[0].tolist()],
-                            "img_width": pm["img_width"],
-                            "img_height": pm["img_height"],
-                            "model": model_name,
-                        }
-                    )
-            if (bs + YOLO_BATCH) % 100 == 0 or bs + YOLO_BATCH >= total:
-                print(f"    {min(bs + YOLO_BATCH, total)}/{total} pages", flush=True)
+                results = model(imgs, conf=confidence, verbose=False)
+                for j, res in enumerate(results):
+                    pm = metas[j]
+                    for box in res.boxes:
+                        class_id = int(box.cls[0].item())
+                        try:
+                            label_name = Label(class_id).name
+                        except ValueError:
+                            continue
+                        all_raw.append(
+                            {
+                                "page_index": pm["index"],
+                                "label": label_name,
+                                "label_id": class_id,
+                                "confidence": round(float(box.conf[0].item()), 3),
+                                "bbox": [round(v, 1) for v in box.xyxy[0].tolist()],
+                                "img_width": pm["img_width"],
+                                "img_height": pm["img_height"],
+                                "model": model_name,
+                            }
+                        )
+                if (bs + YOLO_BATCH) % 100 == 0 or bs + YOLO_BATCH >= total:
+                    print(f"    {min(bs + YOLO_BATCH, total)}/{total} pages", flush=True)
 
-        print(f"    {model_name} done ({time.time() - t0:.0f}s)", flush=True)
-
-    pdf.close()
+            print(f"    {model_name} done ({time.time() - t0:.0f}s)", flush=True)
 
     # Merge across models with label-specific strategies:
     #   CASE_CAPTION, KEY_ICON: medium model only (large hallucinates)
@@ -386,71 +381,69 @@ def pair(
     # Build Document
     from blackletter.scanner import _group_detections_by_page
 
-    src_pdf = fitz.open(str(pdf_path))
     pages_data = _group_detections_by_page(raw, include_page_number_end=True)
 
-    pages = []
-    for pi in sorted(pages_data.keys()):
-        pd = pages_data[pi]
-        if pi < src_pdf.page_count:
-            pw, ph = src_pdf[pi].rect.width, src_pdf[pi].rect.height
-        else:
-            pw, ph = 612.0, 792.0
-        page = Page(
-            index=pi,
-            pdf_width=pw,
-            pdf_height=ph,
-            img_width=pd["img_width"],
-            img_height=pd["img_height"],
-            page_number=pd["page_number"],
-            page_number_end=pd.get("page_number_end"),
+    with fitz.open(str(pdf_path)) as src_pdf:
+        pages = []
+        for pi in sorted(pages_data.keys()):
+            pd = pages_data[pi]
+            if pi < src_pdf.page_count:
+                pw, ph = src_pdf[pi].rect.width, src_pdf[pi].rect.height
+            else:
+                pw, ph = 612.0, 792.0
+            page = Page(
+                index=pi,
+                pdf_width=pw,
+                pdf_height=ph,
+                img_width=pd["img_width"],
+                img_height=pd["img_height"],
+                page_number=pd["page_number"],
+                page_number_end=pd.get("page_number_end"),
+            )
+            for d in pd["detections"]:
+                page.detections.append(BLDetection.from_raw_dict(d, pi, bbox_default=[0, 0, 1, 1]))
+            if page.page_number is None:
+                page.page_number = pi + first_page
+            pages.append(page)
+
+        document = Document(
+            pdf_path=pdf_path,
+            pages=pages,
+            reporter=reporter,
+            volume=volume,
+            first_page=first_page,
+            ocr_applied=True,
         )
-        for d in pd["detections"]:
-            page.detections.append(BLDetection.from_raw_dict(d, pi, bbox_default=[0, 0, 1, 1]))
-        if page.page_number is None:
-            page.page_number = pi + first_page
-        pages.append(page)
 
-    document = Document(
-        pdf_path=pdf_path,
-        pages=pages,
-        reporter=reporter,
-        volume=volume,
-        first_page=first_page,
-        ocr_applied=True,
-    )
+        # Pair
+        t0 = time.time()
+        opinions = _pair_opinions(document, excluded=excluded)
+        print(f"  Paired {len(opinions)} opinions ({time.time() - t0:.0f}s)", flush=True)
 
-    # Pair
-    t0 = time.time()
-    opinions = _pair_opinions(document, excluded=excluded)
-    print(f"  Paired {len(opinions)} opinions ({time.time() - t0:.0f}s)", flush=True)
+        # Each opinion runs from its caption page to its key page.
+        page_ranges: list[tuple[int, int]] = []
+        for idx, (caption, key) in enumerate(opinions):
+            page_ranges.append((caption.page_index, key.page_index))
 
-    # Each opinion runs from its caption page to its key page.
-    page_ranges: list[tuple[int, int]] = []
-    for idx, (caption, key) in enumerate(opinions):
-        page_ranges.append((caption.page_index, key.page_index))
+        # Save opinions.json
+        from blackletter.scanner import _build_opinions_data, _opinion_page_bounds
 
-    # Save opinions.json
-    from blackletter.scanner import _build_opinions_data, _opinion_page_bounds
+        pages_by_index = {p.index: p for p in document.pages}
+        opinions_data = _build_opinions_data(opinions, pages_by_index, src_pdf)
 
-    pages_by_index = {p.index: p for p in document.pages}
-    opinions_data = _build_opinions_data(opinions, pages_by_index, src_pdf)
-
-    # Augment each entry with filename-inference fields unique to this API
-    for idx, entry in enumerate(opinions_data):
-        start_idx, end_idx = page_ranges[idx]
-        first_num, last_num = _opinion_page_bounds(
-            pages_by_index.get(start_idx),
-            pages_by_index.get(end_idx),
-            start_idx,
-            end_idx,
-            first_page,
-        )
-        entry["end_page"] = end_idx
-        entry["first_page_number"] = first_num
-        entry["last_page_number"] = last_num
-
-    src_pdf.close()
+        # Augment each entry with filename-inference fields unique to this API
+        for idx, entry in enumerate(opinions_data):
+            start_idx, end_idx = page_ranges[idx]
+            first_num, last_num = _opinion_page_bounds(
+                pages_by_index.get(start_idx),
+                pages_by_index.get(end_idx),
+                start_idx,
+                end_idx,
+                first_page,
+            )
+            entry["end_page"] = end_idx
+            entry["first_page_number"] = first_num
+            entry["last_page_number"] = last_num
 
     return opinions_data
 
@@ -521,7 +514,6 @@ def build_redacted(
     rects_path = Path(rects) if rects is not None else output_dir / "redaction_rects.json"
 
     # Build minimal Document for the function
-    src_pdf = fitz.open(str(pdf_path))
     det_data = (
         json.loads((output_dir / "detections.json").read_text())
         if (output_dir / "detections.json").exists()
@@ -538,18 +530,18 @@ def build_redacted(
             }
 
     pages = []
-    for i in range(src_pdf.page_count):
-        pd = pages_data.get(i, {"img_width": 1700, "img_height": 2200})
-        pages.append(
-            Page(
-                index=i,
-                pdf_width=src_pdf[i].rect.width,
-                pdf_height=src_pdf[i].rect.height,
-                img_width=pd["img_width"],
-                img_height=pd["img_height"],
+    with fitz.open(str(pdf_path)) as src_pdf:
+        for i in range(src_pdf.page_count):
+            pd = pages_data.get(i, {"img_width": 1700, "img_height": 2200})
+            pages.append(
+                Page(
+                    index=i,
+                    pdf_width=src_pdf[i].rect.width,
+                    pdf_height=src_pdf[i].rect.height,
+                    img_width=pd["img_width"],
+                    img_height=pd["img_height"],
+                )
             )
-        )
-    src_pdf.close()
 
     document = Document(pdf_path=pdf_path, pages=pages, ocr_applied=True)
 
@@ -702,124 +694,121 @@ def generate(
         else:
             filenames.append(name)
 
-    src = fitz.open(str(pdf_path))
+    with fitz.open(str(pdf_path)) as src:
 
-    def _apply_page(fitz_page, src_idx, opinion, mode):
-        """Apply all rects for one page in one pass.
+        def _apply_page(fitz_page, src_idx, opinion, mode):
+            """Apply all rects for one page in one pass.
 
-        :param fitz_page: The ``fitz.Page`` to apply redactions to.
-        :param src_idx: Source page index in the original PDF.
-        :param opinion: Opinion dict (or ``None`` for full-redacted mode).
-        :param mode: One of ``"full"`` (all rects, no outside-opinion
-            whiteout) or ``"redacted"`` (all rects + outside-opinion
-            whiteout).
-        """
-        # Page rects (margins + redactions), all PDF points
-        for r in pages_rects.get(str(src_idx), []):
-            rect = fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
-            if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
-                continue
-            if r["type"] == "margin":
-                fill = (1, 1, 1)
-            else:
-                fill = (0, 0, 0) if r["fill"] == "black" else (1, 1, 1)
-            fitz_page.add_redact_annot(rect, fill=fill)
-
-        # Outside-opinion whiteout (skip for full redacted)
-        if opinion is not None and mode != "full":
-            for orect in opinion.get("outside_rects", []):
-                if orect["page_index"] != src_idx:
+            :param fitz_page: The ``fitz.Page`` to apply redactions to.
+            :param src_idx: Source page index in the original PDF.
+            :param opinion: Opinion dict (or ``None`` for full-redacted mode).
+            :param mode: One of ``"full"`` (all rects, no outside-opinion
+                whiteout) or ``"redacted"`` (all rects + outside-opinion
+                whiteout).
+            """
+            # Page rects (margins + redactions), all PDF points
+            for r in pages_rects.get(str(src_idx), []):
+                rect = fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
+                if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
                     continue
-                rect = fitz.Rect(orect["x0"], orect["y0"] + 3, orect["x1"], orect["y1"])
-                if not rect.is_empty:
-                    fitz_page.add_redact_annot(rect, fill=(1, 1, 1))
+                if r["type"] == "margin":
+                    fill = (1, 1, 1)
+                else:
+                    fill = (0, 0, 0) if r["fill"] == "black" else (1, 1, 1)
+                fitz_page.add_redact_annot(rect, fill=fill)
 
-        fitz_page.apply_redactions()
-
-    # ── Full redacted PDF ──
-    t0 = time.time()
-    full_out = fitz.open()
-    full_out.insert_pdf(src)
-    for page_idx in range(full_out.page_count):
-        _apply_page(full_out[page_idx], page_idx, None, "full")
-        if progress_callback and ((page_idx + 1) % 20 == 0 or page_idx == full_out.page_count - 1):
-            progress_callback(page_idx + 1, full_out.page_count, "Redacting pages...")
-
-    # Name: reporter.volume.first_page.last_page.redacted.pdf
-    first_pn = opinions[0].get("first_page_number", 1)
-    last_pn = opinions[-1].get("last_page_number", first_pn)
-    full_name = f"{prefix}{first_pn}.{last_pn}.redacted.pdf"
-    full_path = output_dir / full_name
-    full_out.save(str(full_path), garbage=4, deflate=True)
-    full_out.close()
-    print(
-        f"  Full redacted: {full_path.name} ({full_path.stat().st_size / 1024 / 1024:.1f} MB, {time.time() - t0:.0f}s)",
-        flush=True,
-    )
-
-    # ── Split opinions ──
-    redacted_dir = output_dir / "redacted"
-    redacted_dir.mkdir(exist_ok=True)
-
-    if unredacted:
-        unredacted_dir = output_dir / "unredacted"
-        unredacted_dir.mkdir(exist_ok=True)
-
-    if llm:
-        llm_dir = output_dir / "llm"
-        llm_dir.mkdir(exist_ok=True)
-
-    t0 = time.time()
-
-    # ── Redacted + unredacted: one PDF per opinion ──
-    for i, op in enumerate(opinions):
-        start_idx = op["caption_page"]
-        end_idx = op["end_page"]
-        filename = filenames[i]
-
-        out = fitz.open()
-        out.insert_pdf(src, from_page=start_idx, to_page=end_idx)
-        for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
-            _apply_page(out[local_idx], src_idx, op, "redacted")
-        out.save(str(redacted_dir / filename), garbage=4, deflate=True)
-        out.close()
-
-        if unredacted:
-            out = fitz.open()
-            out.insert_pdf(src, from_page=start_idx, to_page=end_idx)
-            for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
-                for orect in op.get("outside_rects", []):
+            # Outside-opinion whiteout (skip for full redacted)
+            if opinion is not None and mode != "full":
+                for orect in opinion.get("outside_rects", []):
                     if orect["page_index"] != src_idx:
                         continue
-                    rect = fitz.Rect(orect["x0"], orect["y0"], orect["x1"], orect["y1"])
+                    rect = fitz.Rect(orect["x0"], orect["y0"] + 3, orect["x1"], orect["y1"])
                     if not rect.is_empty:
-                        out[local_idx].add_redact_annot(rect, fill=(1, 1, 1))
-                out[local_idx].apply_redactions()
-            out.save(str(unredacted_dir / filename), garbage=4, deflate=True)
-            out.close()
+                        fitz_page.add_redact_annot(rect, fill=(1, 1, 1))
 
-        done = i + 1
-        if done % 20 == 0 or done == len(opinions):
-            print(f"    Redacted {done}/{len(opinions)}", flush=True)
+            fitz_page.apply_redactions()
 
-    # ── LLM per-page split with CASEEND stamps on Key icons (opt-in) ──
-    if llm:
-        from blackletter.process import _split_llm_pages
+        # ── Full redacted PDF ──
+        t0 = time.time()
+        # Name: reporter.volume.first_page.last_page.redacted.pdf
+        first_pn = opinions[0].get("first_page_number", 1)
+        last_pn = opinions[-1].get("last_page_number", first_pn)
+        full_name = f"{prefix}{first_pn}.{last_pn}.redacted.pdf"
+        full_path = output_dir / full_name
+        with fitz.open() as full_out:
+            full_out.insert_pdf(src)
+            for page_idx in range(full_out.page_count):
+                _apply_page(full_out[page_idx], page_idx, None, "full")
+                if progress_callback and (
+                    (page_idx + 1) % 20 == 0 or page_idx == full_out.page_count - 1
+                ):
+                    progress_callback(page_idx + 1, full_out.page_count, "Redacting pages...")
+            full_out.save(str(full_path), garbage=4, deflate=True)
+        print(
+            f"  Full redacted: {full_path.name} ({full_path.stat().st_size / 1024 / 1024:.1f} MB, {time.time() - t0:.0f}s)",
+            flush=True,
+        )
 
-        t_llm = time.time()
-        key_by_page: dict[int, list[fitz.Rect]] = {}
-        for pi_str, rs in pages_rects.items():
-            rects = [
-                fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
-                for r in rs
-                if r.get("type") == "KEY_ICON"
-            ]
-            if rects:
-                key_by_page[int(pi_str)] = rects
-        total = _split_llm_pages(full_path, key_by_page, llm_dir)
-        print(f"    LLM {total} pages ({time.time() - t_llm:.0f}s)", flush=True)
+        # ── Split opinions ──
+        redacted_dir = output_dir / "redacted"
+        redacted_dir.mkdir(exist_ok=True)
 
-    src.close()
+        if unredacted:
+            unredacted_dir = output_dir / "unredacted"
+            unredacted_dir.mkdir(exist_ok=True)
+
+        if llm:
+            llm_dir = output_dir / "llm"
+            llm_dir.mkdir(exist_ok=True)
+
+        t0 = time.time()
+
+        # ── Redacted + unredacted: one PDF per opinion ──
+        for i, op in enumerate(opinions):
+            start_idx = op["caption_page"]
+            end_idx = op["end_page"]
+            filename = filenames[i]
+
+            with fitz.open() as out:
+                out.insert_pdf(src, from_page=start_idx, to_page=end_idx)
+                for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
+                    _apply_page(out[local_idx], src_idx, op, "redacted")
+                out.save(str(redacted_dir / filename), garbage=4, deflate=True)
+
+            if unredacted:
+                with fitz.open() as out:
+                    out.insert_pdf(src, from_page=start_idx, to_page=end_idx)
+                    for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
+                        for orect in op.get("outside_rects", []):
+                            if orect["page_index"] != src_idx:
+                                continue
+                            rect = fitz.Rect(orect["x0"], orect["y0"], orect["x1"], orect["y1"])
+                            if not rect.is_empty:
+                                out[local_idx].add_redact_annot(rect, fill=(1, 1, 1))
+                        out[local_idx].apply_redactions()
+                    out.save(str(unredacted_dir / filename), garbage=4, deflate=True)
+
+            done = i + 1
+            if done % 20 == 0 or done == len(opinions):
+                print(f"    Redacted {done}/{len(opinions)}", flush=True)
+
+        # ── LLM per-page split with CASEEND stamps on Key icons (opt-in) ──
+        if llm:
+            from blackletter.process import _split_llm_pages
+
+            t_llm = time.time()
+            key_by_page: dict[int, list[fitz.Rect]] = {}
+            for pi_str, rs in pages_rects.items():
+                rects = [
+                    fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
+                    for r in rs
+                    if r.get("type") == "KEY_ICON"
+                ]
+                if rects:
+                    key_by_page[int(pi_str)] = rects
+            total = _split_llm_pages(full_path, key_by_page, llm_dir)
+            print(f"    LLM {total} pages ({time.time() - t_llm:.0f}s)", flush=True)
+
     print(f"  Split complete ({time.time() - t0:.0f}s)", flush=True)
 
     result = {

--- a/blackletter/margins.py
+++ b/blackletter/margins.py
@@ -67,52 +67,51 @@ def compute_margin_rects(
         each rect is a dict with ``x0``, ``y0``, ``x1``, ``y1``.
     """
     pdf_path = Path(pdf_path)
-    doc = fitz.open(str(pdf_path))
     result = []
 
-    for page_idx in range(len(doc)):
-        page = doc[page_idx]
-        pw = page.rect.width
-        ph = page.rect.height
-        bounds = _text_bounds(page, pw)
-        if bounds is None:
-            result.append({"page_index": page_idx, "rects": []})
-            continue
+    with fitz.open(str(pdf_path)) as doc:
+        for page_idx in range(len(doc)):
+            page = doc[page_idx]
+            pw = page.rect.width
+            ph = page.rect.height
+            bounds = _text_bounds(page, pw)
+            if bounds is None:
+                result.append({"page_index": page_idx, "rects": []})
+                continue
 
-        left, top, right, bottom = bounds
-        safe_left = max(0, left - buffer)
-        safe_top = max(0, top - buffer)
-        safe_right = min(pw, right + buffer)
-        safe_bottom = min(ph, bottom + buffer)
+            left, top, right, bottom = bounds
+            safe_left = max(0, left - buffer)
+            safe_top = max(0, top - buffer)
+            safe_right = min(pw, right + buffer)
+            safe_bottom = min(ph, bottom + buffer)
 
-        rects = []
-        if safe_left > 1:
-            rects.append({"x0": 0, "y0": 0, "x1": round(safe_left, 1), "y1": round(ph, 1)})
-        if pw - safe_right > 1:
-            rects.append(
-                {"x0": round(safe_right, 1), "y0": 0, "x1": round(pw, 1), "y1": round(ph, 1)}
-            )
-        if safe_top > 1:
-            rects.append(
-                {
-                    "x0": round(safe_left, 1),
-                    "y0": 0,
-                    "x1": round(safe_right, 1),
-                    "y1": round(safe_top, 1),
-                }
-            )
-        if ph - safe_bottom > 1:
-            rects.append(
-                {
-                    "x0": round(safe_left, 1),
-                    "y0": round(safe_bottom, 1),
-                    "x1": round(safe_right, 1),
-                    "y1": round(ph, 1),
-                }
-            )
-        result.append({"page_index": page_idx, "rects": rects})
+            rects = []
+            if safe_left > 1:
+                rects.append({"x0": 0, "y0": 0, "x1": round(safe_left, 1), "y1": round(ph, 1)})
+            if pw - safe_right > 1:
+                rects.append(
+                    {"x0": round(safe_right, 1), "y0": 0, "x1": round(pw, 1), "y1": round(ph, 1)}
+                )
+            if safe_top > 1:
+                rects.append(
+                    {
+                        "x0": round(safe_left, 1),
+                        "y0": 0,
+                        "x1": round(safe_right, 1),
+                        "y1": round(safe_top, 1),
+                    }
+                )
+            if ph - safe_bottom > 1:
+                rects.append(
+                    {
+                        "x0": round(safe_left, 1),
+                        "y0": round(safe_bottom, 1),
+                        "x1": round(safe_right, 1),
+                        "y1": round(ph, 1),
+                    }
+                )
+            result.append({"page_index": page_idx, "rects": rects})
 
-    doc.close()
     return result
 
 
@@ -137,94 +136,97 @@ def clean_margins(
     if output_path is None:
         output_path = pdf_path
 
-    doc = fitz.open(str(pdf_path))
     cleaned = 0
 
-    # Detect bitonal. apply_redactions corrupts CCITT G4 streams
-    _sample_imgs = doc[0].get_images(full=True) if doc.page_count else []
-    is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
+    with fitz.open(str(pdf_path)) as doc:
+        # Detect bitonal. apply_redactions corrupts CCITT G4 streams
+        _sample_imgs = doc[0].get_images(full=True) if doc.page_count else []
+        is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
 
-    for page_idx in range(len(doc)):
-        page = doc[page_idx]
-        pw = page.rect.width
-        ph = page.rect.height
+        for page_idx in range(len(doc)):
+            page = doc[page_idx]
+            pw = page.rect.width
+            ph = page.rect.height
 
-        bounds = _text_bounds(page, pw)
-        if bounds is None:
-            continue
+            bounds = _text_bounds(page, pw)
+            if bounds is None:
+                continue
 
-        left, top, right, bottom = bounds
+            left, top, right, bottom = bounds
 
-        # Apply buffer (shrink the content area we protect)
-        safe_left = left - buffer
-        safe_top = top - buffer
-        safe_right = right + buffer
-        safe_bottom = bottom + buffer
+            # Apply buffer (shrink the content area we protect)
+            safe_left = left - buffer
+            safe_top = top - buffer
+            safe_right = right + buffer
+            safe_bottom = bottom + buffer
 
-        # Clamp to page bounds
-        safe_left = max(0, safe_left)
-        safe_top = max(0, safe_top)
-        safe_right = min(pw, safe_right)
-        safe_bottom = min(ph, safe_bottom)
+            # Clamp to page bounds
+            safe_left = max(0, safe_left)
+            safe_top = max(0, safe_top)
+            safe_right = min(pw, safe_right)
+            safe_bottom = min(ph, safe_bottom)
 
-        # White out the four margin strips
-        white = (1, 1, 1)
-        margin_rects = []
+            # White out the four margin strips
+            white = (1, 1, 1)
+            margin_rects = []
 
-        # Left margin
-        if safe_left > 1:
-            r = fitz.Rect(0, 0, safe_left, ph)
-            margin_rects.append((r, white))
-            page.add_redact_annot(r, fill=white)
+            # Left margin
+            if safe_left > 1:
+                r = fitz.Rect(0, 0, safe_left, ph)
+                margin_rects.append((r, white))
+                page.add_redact_annot(r, fill=white)
 
-        # Right margin
-        if pw - safe_right > 1:
-            r = fitz.Rect(safe_right, 0, pw, ph)
-            margin_rects.append((r, white))
-            page.add_redact_annot(r, fill=white)
+            # Right margin
+            if pw - safe_right > 1:
+                r = fitz.Rect(safe_right, 0, pw, ph)
+                margin_rects.append((r, white))
+                page.add_redact_annot(r, fill=white)
 
-        # Top margin (between left and right content edges)
-        if safe_top > 1:
-            r = fitz.Rect(safe_left, 0, safe_right, safe_top)
-            margin_rects.append((r, white))
-            page.add_redact_annot(r, fill=white)
+            # Top margin (between left and right content edges)
+            if safe_top > 1:
+                r = fitz.Rect(safe_left, 0, safe_right, safe_top)
+                margin_rects.append((r, white))
+                page.add_redact_annot(r, fill=white)
 
-        # Bottom margin (between left and right content edges)
-        if ph - safe_bottom > 1:
-            r = fitz.Rect(safe_left, safe_bottom, safe_right, ph)
-            margin_rects.append((r, white))
-            page.add_redact_annot(r, fill=white)
+            # Bottom margin (between left and right content edges)
+            if ph - safe_bottom > 1:
+                r = fitz.Rect(safe_left, safe_bottom, safe_right, ph)
+                margin_rects.append((r, white))
+                page.add_redact_annot(r, fill=white)
 
-        if is_bitonal and margin_rects:
-            from blackletter.process import _redact_bitonal_image
+            if is_bitonal and margin_rects:
+                from blackletter.process import _redact_bitonal_image
 
-            _redact_bitonal_image(page, doc, margin_rects)
-            page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+                _redact_bitonal_image(page, doc, margin_rects)
+                page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+            else:
+                page.apply_redactions()
+            # Overdraw with fill-only rects to cover 1pt stroke from apply_redactions
+            for rect, color in margin_rects:
+                page.draw_rect(rect, fill=color, color=None, width=0)
+            cleaned += 1
+
+        if not is_bitonal:
+            # Recompress images. apply_redactions converts JPEGs to PNG, inflating size
+            from blackletter.scanner import recompress_images
+
+            recompress_images(doc, quality=65)
+
+        total = len(doc)
+
+        if output_path == pdf_path:
+            # Can't save over the source directly, use temp file
+            with tempfile.NamedTemporaryFile(
+                suffix=".pdf", delete=False, dir=pdf_path.parent
+            ) as tmp:
+                tmp_path = Path(tmp.name)
+            doc.save(str(tmp_path), garbage=4, deflate=True)
         else:
-            page.apply_redactions()
-        # Overdraw with fill-only rects to cover 1pt stroke from apply_redactions
-        for rect, color in margin_rects:
-            page.draw_rect(rect, fill=color, color=None, width=0)
-        cleaned += 1
+            doc.save(str(output_path), garbage=4, deflate=True)
+            tmp_path = None
 
-    if not is_bitonal:
-        # Recompress images. apply_redactions converts JPEGs to PNG, inflating size
-        from blackletter.scanner import recompress_images
-
-        recompress_images(doc, quality=65)
-
-    total = len(doc)
-
-    if output_path == pdf_path:
-        # Can't save over the source directly, use temp file
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False, dir=pdf_path.parent) as tmp:
-            tmp_path = Path(tmp.name)
-        doc.save(str(tmp_path), garbage=4, deflate=True)
-        doc.close()
+    if tmp_path is not None:
         tmp_path.replace(pdf_path)
-    else:
-        doc.save(str(output_path), garbage=4, deflate=True)
-        doc.close()
 
     logger.info("Margin cleanup: %d/%d pages cleaned", cleaned, total)
     return output_path

--- a/blackletter/process.py
+++ b/blackletter/process.py
@@ -177,21 +177,20 @@ def _split_llm_pages(
         for pdf_idx in range(total):
             page_num = pdf_idx + 1
             page_pdf_path = output_dir / f"page_{page_num:04d}.pdf"
-            single = fitz.open()
-            single.insert_pdf(src_doc, from_page=pdf_idx, to_page=pdf_idx)
-            krs = key_by_page.get(pdf_idx, [])
-            if krs:
-                page = single[0]
-                for rect in krs:
-                    page.insert_text(
-                        (rect.x0 + 2, rect.y0 + rect.height / 2 + 3),
-                        "<--CASEEND-->",
-                        fontsize=8,
-                        fontname="helv",
-                        render_mode=3,
-                    )
-            single.save(str(page_pdf_path))
-            single.close()
+            with fitz.open() as single:
+                single.insert_pdf(src_doc, from_page=pdf_idx, to_page=pdf_idx)
+                krs = key_by_page.get(pdf_idx, [])
+                if krs:
+                    page = single[0]
+                    for rect in krs:
+                        page.insert_text(
+                            (rect.x0 + 2, rect.y0 + rect.height / 2 + 3),
+                            "<--CASEEND-->",
+                            fontsize=8,
+                            fontname="helv",
+                            render_mode=3,
+                        )
+                single.save(str(page_pdf_path))
     return total
 
 
@@ -200,30 +199,29 @@ def _apply_margin_rects(pdf_path: Path, margin_rects_path: Path) -> None:
     import json as _json
 
     margin_data = _json.loads(margin_rects_path.read_text())
-    doc = fitz.open(str(pdf_path))
-    _sample_imgs = doc[0].get_images(full=True) if doc.page_count else []
-    is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
-    for entry in margin_data:
-        pi = entry["page_index"]
-        if pi >= doc.page_count:
-            continue
-        page = doc[pi]
-        white = (1, 1, 1)
-        page_margin_rects = []
-        for r in entry.get("rects", []):
-            rect = fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
-            page.add_redact_annot(rect, fill=white)
-            page_margin_rects.append((rect, white))
-        if is_bitonal and page_margin_rects:
-            _redact_bitonal_image(page, doc, page_margin_rects)
-            page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
-        else:
-            page.apply_redactions()
-        # Overdraw with fill-only rects to cover 1pt stroke from apply_redactions
-        for rect, color in page_margin_rects:
-            page.draw_rect(rect, fill=color, color=None, width=0)
-    doc.save(str(pdf_path), incremental=True, encryption=fitz.PDF_ENCRYPT_KEEP)
-    doc.close()
+    with fitz.open(str(pdf_path)) as doc:
+        _sample_imgs = doc[0].get_images(full=True) if doc.page_count else []
+        is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
+        for entry in margin_data:
+            pi = entry["page_index"]
+            if pi >= doc.page_count:
+                continue
+            page = doc[pi]
+            white = (1, 1, 1)
+            page_margin_rects = []
+            for r in entry.get("rects", []):
+                rect = fitz.Rect(r["x0"], r["y0"], r["x1"], r["y1"])
+                page.add_redact_annot(rect, fill=white)
+                page_margin_rects.append((rect, white))
+            if is_bitonal and page_margin_rects:
+                _redact_bitonal_image(page, doc, page_margin_rects)
+                page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+            else:
+                page.apply_redactions()
+            # Overdraw with fill-only rects to cover 1pt stroke from apply_redactions
+            for rect, color in page_margin_rects:
+                page.draw_rect(rect, fill=color, color=None, width=0)
+        doc.save(str(pdf_path), incremental=True, encryption=fitz.PDF_ENCRYPT_KEEP)
 
 
 def _redact_bitonal_image(fitz_page, fitz_doc, redaction_rects):
@@ -292,208 +290,208 @@ def compute_redaction_rects(
     pages_by_index = {p.index: p for p in document.pages}
     mid = document.pages[0].midpoint
 
-    src_pdf = fitz.open(str(document.pdf_path))
-
-    # Pre-compute headnote rects
-    all_keys, all_dets = _sorted_detections(document, mid)
-    all_headnote_rects = []
-    for caption, key in opinions:
-        opinion_dets = _detections_in_range(
-            all_keys, all_dets, caption.sort_key(mid), key.sort_key(mid)
-        )
-        end_marker = _find_redaction_end(
-            opinion_dets, caption, key, mid, reporter=document.reporter
-        )
-        if end_marker is not None:
-            start = _find_redaction_start(opinion_dets, caption, mid)
-            all_headnote_rects.extend(
-                _redaction_rects(
-                    caption,
-                    end_marker,
-                    pages_by_index,
-                    start_marker=start if start is not caption else None,
-                )
+    with fitz.open(str(document.pdf_path)) as src_pdf:
+        # Pre-compute headnote rects
+        all_keys, all_dets = _sorted_detections(document, mid)
+        all_headnote_rects = []
+        for caption, key in opinions:
+            opinion_dets = _detections_in_range(
+                all_keys, all_dets, caption.sort_key(mid), key.sort_key(mid)
             )
-        else:
-            all_headnote_rects.extend(
-                _headnote_fallback_rects(opinion_dets, caption, pages_by_index, mid)
+            end_marker = _find_redaction_end(
+                opinion_dets, caption, key, mid, reporter=document.reporter
             )
-
-    # Refine headnote rects to line-level with docTR
-    if all_headnote_rects and not skip_doctr:
-        all_headnote_rects = refine_headnote_rects(src_pdf, all_headnote_rects, pages_by_index)
-
-    result = {}
-
-    def _add_px(page_idx, x0, y0, x1, y1, fill, rtype):
-        """Add rect in image pixel coordinates."""
-        if x0 >= x1 or y0 >= y1:
-            return
-        if page_idx not in result:
-            result[page_idx] = []
-        result[page_idx].append(
-            {
-                "x0": round(x0, 1),
-                "y0": round(y0, 1),
-                "x1": round(x1, 1),
-                "y1": round(y1, 1),
-                "fill": fill,
-                "type": rtype,
-            }
-        )
-
-    for page in document.pages:
-        src_idx = page.index
-        fitz_page = src_pdf[src_idx]
-        sx, sy = page.scale_x, page.scale_y
-
-        # Headnote zones — compute in image pixel coords
-        hb, ft = _margin_bounds(page)
-
-        # Use right-column HEADNOTE detections to establish the inner column
-        # boundary: the leftmost x0 of any right-column HEADNOTE is where the
-        # right column starts. The left column ends 10px before that.
-        mid_px = page.midpoint
-        # Right-column HEADNOTEs: center in right half, left edge at least 75% across
-        right_hn = [
-            d
-            for d in page.detections
-            if d.label == Label.HEADNOTE and d.bbox.center_x > mid_px and d.bbox.x1 >= mid_px * 0.75
-        ]
-        right_col_inner_pdf = min(d.bbox.x1 for d in right_hn) * sx if right_hn else None
-
-        for rect_page_idx, rect in all_headnote_rects:
-            if rect_page_idx == src_idx:
-                # Determine column from the raw rect center BEFORE tightening
-                mid_pdf = mid_px * sx
-                raw_center_x = (rect.x0 + rect.x1) / 2
-                is_left_col = raw_center_x < mid_pdf
-                # Tighten to text in PDF points first
-                tight = _tighten_to_text(fitz_page, rect)
-                if tight is not None:
-                    rect = tight
-                text_bot = _text_bottom(fitz_page, rect)
-                text_left, text_right = _text_x_bounds(fitz_page, rect)
-                if right_col_inner_pdf is not None:
-                    if is_left_col:
-                        new_x0 = text_left
-                        new_x1 = min(text_right, right_col_inner_pdf)
-                    else:
-                        new_x0 = max(text_left, right_col_inner_pdf)
-                        new_x1 = text_right
-                else:
-                    # No right-column headnotes — keep original column x bounds
-                    new_x0 = rect.x0
-                    new_x1 = rect.x1
-                rect = fitz.Rect(
-                    new_x0,
-                    max(rect.y0, hb),
-                    new_x1,
-                    min(rect.y1, ft, text_bot),
+            if end_marker is not None:
+                start = _find_redaction_start(opinion_dets, caption, mid)
+                all_headnote_rects.extend(
+                    _redaction_rects(
+                        caption,
+                        end_marker,
+                        pages_by_index,
+                        start_marker=start if start is not caption else None,
+                    )
                 )
-                if rect.is_empty or rect.x0 >= rect.x1 or rect.y0 >= rect.y1:
-                    continue
-                # Convert to image pixels
-                rx0 = rect.x0 / sx
-                ry0 = rect.y0 / sy
-                rx1 = rect.x1 / sx
-                ry1 = rect.y1 / sy
-                _add_px(src_idx, rx0, ry0, rx1, ry1, "black", "headnote")
-
-        # Per-detection redactions — output in image pixel coords
-        for d in page.detections:
-            if d.label not in (_REDACT_WHITE | _REDACT_BLACK):
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            _is_approved = approved and _check_excluded(d, approved)
-            if not _is_approved and d.confidence < LABEL_CONFIDENCE.get(
-                d.label, CONFIDENCE_THRESHOLD
-            ):
-                continue
-            _skip_tighten = d.label in (Label.HEADNOTE_BRACKET, Label.STATE_ABBREVIATION)
-            if _skip_tighten:
-                # Use raw YOLO bbox (image pixels)
-                fill = "black" if d.label in _REDACT_BLACK else "white"
-                _add_px(src_idx, d.bbox.x1, d.bbox.y1, d.bbox.x2, d.bbox.y2, fill, d.label.name)
             else:
-                # Tighten in PDF coords, convert back to pixels
-                rect = d.bbox.to_fitz_pdf_rect(sx, sy)
-                tight = _tighten_to_text(fitz_page, rect, skip=False)
-                if tight is not None:
-                    rect = tight
-                fill = "black" if d.label in _REDACT_BLACK else "white"
+                all_headnote_rects.extend(
+                    _headnote_fallback_rects(opinion_dets, caption, pages_by_index, mid)
+                )
+
+        # Refine headnote rects to line-level with docTR
+        if all_headnote_rects and not skip_doctr:
+            all_headnote_rects = refine_headnote_rects(src_pdf, all_headnote_rects, pages_by_index)
+
+        result = {}
+
+        def _add_px(page_idx, x0, y0, x1, y1, fill, rtype):
+            """Add rect in image pixel coordinates."""
+            if x0 >= x1 or y0 >= y1:
+                return
+            if page_idx not in result:
+                result[page_idx] = []
+            result[page_idx].append(
+                {
+                    "x0": round(x0, 1),
+                    "y0": round(y0, 1),
+                    "x1": round(x1, 1),
+                    "y1": round(y1, 1),
+                    "fill": fill,
+                    "type": rtype,
+                }
+            )
+
+        for page in document.pages:
+            src_idx = page.index
+            fitz_page = src_pdf[src_idx]
+            sx, sy = page.scale_x, page.scale_y
+
+            # Headnote zones — compute in image pixel coords
+            hb, ft = _margin_bounds(page)
+
+            # Use right-column HEADNOTE detections to establish the inner column
+            # boundary: the leftmost x0 of any right-column HEADNOTE is where the
+            # right column starts. The left column ends 10px before that.
+            mid_px = page.midpoint
+            # Right-column HEADNOTEs: center in right half, left edge at least 75% across
+            right_hn = [
+                d
+                for d in page.detections
+                if d.label == Label.HEADNOTE
+                and d.bbox.center_x > mid_px
+                and d.bbox.x1 >= mid_px * 0.75
+            ]
+            right_col_inner_pdf = min(d.bbox.x1 for d in right_hn) * sx if right_hn else None
+
+            for rect_page_idx, rect in all_headnote_rects:
+                if rect_page_idx == src_idx:
+                    # Determine column from the raw rect center BEFORE tightening
+                    mid_pdf = mid_px * sx
+                    raw_center_x = (rect.x0 + rect.x1) / 2
+                    is_left_col = raw_center_x < mid_pdf
+                    # Tighten to text in PDF points first
+                    tight = _tighten_to_text(fitz_page, rect)
+                    if tight is not None:
+                        rect = tight
+                    text_bot = _text_bottom(fitz_page, rect)
+                    text_left, text_right = _text_x_bounds(fitz_page, rect)
+                    if right_col_inner_pdf is not None:
+                        if is_left_col:
+                            new_x0 = text_left
+                            new_x1 = min(text_right, right_col_inner_pdf)
+                        else:
+                            new_x0 = max(text_left, right_col_inner_pdf)
+                            new_x1 = text_right
+                    else:
+                        # No right-column headnotes — keep original column x bounds
+                        new_x0 = rect.x0
+                        new_x1 = rect.x1
+                    rect = fitz.Rect(
+                        new_x0,
+                        max(rect.y0, hb),
+                        new_x1,
+                        min(rect.y1, ft, text_bot),
+                    )
+                    if rect.is_empty or rect.x0 >= rect.x1 or rect.y0 >= rect.y1:
+                        continue
+                    # Convert to image pixels
+                    rx0 = rect.x0 / sx
+                    ry0 = rect.y0 / sy
+                    rx1 = rect.x1 / sx
+                    ry1 = rect.y1 / sy
+                    _add_px(src_idx, rx0, ry0, rx1, ry1, "black", "headnote")
+
+            # Per-detection redactions — output in image pixel coords
+            for d in page.detections:
+                if d.label not in (_REDACT_WHITE | _REDACT_BLACK):
+                    continue
+                if _check_excluded(d, excluded):
+                    continue
+                _is_approved = approved and _check_excluded(d, approved)
+                if not _is_approved and d.confidence < LABEL_CONFIDENCE.get(
+                    d.label, CONFIDENCE_THRESHOLD
+                ):
+                    continue
+                _skip_tighten = d.label in (Label.HEADNOTE_BRACKET, Label.STATE_ABBREVIATION)
+                if _skip_tighten:
+                    # Use raw YOLO bbox (image pixels)
+                    fill = "black" if d.label in _REDACT_BLACK else "white"
+                    _add_px(src_idx, d.bbox.x1, d.bbox.y1, d.bbox.x2, d.bbox.y2, fill, d.label.name)
+                else:
+                    # Tighten in PDF coords, convert back to pixels
+                    rect = d.bbox.to_fitz_pdf_rect(sx, sy)
+                    tight = _tighten_to_text(fitz_page, rect, skip=False)
+                    if tight is not None:
+                        rect = tight
+                    fill = "black" if d.label in _REDACT_BLACK else "white"
+                    _add_px(
+                        src_idx,
+                        rect.x0 / sx,
+                        rect.y0 / sy,
+                        rect.x1 / sx,
+                        rect.y1 / sy,
+                        fill,
+                        d.label.name,
+                    )
+
+            # CASE_SEQUENCE
+            caption_rects = []
+            for d in page.detections:
+                if d.label == Label.CASE_CAPTION:
+                    caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
+
+            _CS_INSET = 3.0
+            _CS_MIN_PX = 40  # min width/height in image pixels
+            _CS_MAX_PX = 60  # max width/height in image pixels
+            for d in page.detections:
+                if d.label != Label.CASE_SEQUENCE:
+                    continue
+                if _check_excluded(d, excluded):
+                    continue
+                # Clamp raw YOLO bbox to min/max size in pixels, then convert
+                bx0, by0 = d.bbox.x1, d.bbox.y1
+                bx1, by1 = d.bbox.x2, d.bbox.y2
+                cx, cy = (bx0 + bx1) / 2, (by0 + by1) / 2
+                pw = max(_CS_MIN_PX, min(bx1 - bx0, _CS_MAX_PX))
+                ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
+                bx0, bx1 = cx - pw / 2, cx + pw / 2
+                by0, by1 = cy - ph / 2, cy + ph / 2
+                rect = BBox(bx0, by0, bx1, by1).to_fitz_pdf_rect(sx, sy)
+                # Small inset
+                rect = fitz.Rect(
+                    rect.x0 + _CS_INSET,
+                    rect.y0 + _CS_INSET,
+                    rect.x1 - _CS_INSET,
+                    rect.y1 - _CS_INSET,
+                )
+                if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
+                    continue
                 _add_px(
                     src_idx,
                     rect.x0 / sx,
                     rect.y0 / sy,
                     rect.x1 / sx,
                     rect.y1 / sy,
-                    fill,
-                    d.label.name,
+                    "black",
+                    "CASE_SEQUENCE",
                 )
 
-        # CASE_SEQUENCE
-        caption_rects = []
-        for d in page.detections:
-            if d.label == Label.CASE_CAPTION:
-                caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
+            # Key icons — use raw YOLO bbox (image pixels)
+            valid_key_icons = {
+                id(d)
+                for d in _filter_key_icons_by_size(
+                    [x for x in page.detections if x.label == Label.KEY_ICON]
+                )
+            }
+            for d in page.detections:
+                if d.label != Label.KEY_ICON:
+                    continue
+                if id(d) not in valid_key_icons:
+                    continue
+                if _check_excluded(d, excluded):
+                    continue
+                if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
+                    continue
+                _add_px(src_idx, d.bbox.x1, d.bbox.y1, d.bbox.x2, d.bbox.y2, "black", "KEY_ICON")
 
-        _CS_INSET = 3.0
-        _CS_MIN_PX = 40  # min width/height in image pixels
-        _CS_MAX_PX = 60  # max width/height in image pixels
-        for d in page.detections:
-            if d.label != Label.CASE_SEQUENCE:
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            # Clamp raw YOLO bbox to min/max size in pixels, then convert
-            bx0, by0 = d.bbox.x1, d.bbox.y1
-            bx1, by1 = d.bbox.x2, d.bbox.y2
-            cx, cy = (bx0 + bx1) / 2, (by0 + by1) / 2
-            pw = max(_CS_MIN_PX, min(bx1 - bx0, _CS_MAX_PX))
-            ph = max(_CS_MIN_PX, min(by1 - by0, _CS_MAX_PX))
-            bx0, bx1 = cx - pw / 2, cx + pw / 2
-            by0, by1 = cy - ph / 2, cy + ph / 2
-            rect = BBox(bx0, by0, bx1, by1).to_fitz_pdf_rect(sx, sy)
-            # Small inset
-            rect = fitz.Rect(
-                rect.x0 + _CS_INSET,
-                rect.y0 + _CS_INSET,
-                rect.x1 - _CS_INSET,
-                rect.y1 - _CS_INSET,
-            )
-            if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
-                continue
-            _add_px(
-                src_idx,
-                rect.x0 / sx,
-                rect.y0 / sy,
-                rect.x1 / sx,
-                rect.y1 / sy,
-                "black",
-                "CASE_SEQUENCE",
-            )
-
-        # Key icons — use raw YOLO bbox (image pixels)
-        valid_key_icons = {
-            id(d)
-            for d in _filter_key_icons_by_size(
-                [x for x in page.detections if x.label == Label.KEY_ICON]
-            )
-        }
-        for d in page.detections:
-            if d.label != Label.KEY_ICON:
-                continue
-            if id(d) not in valid_key_icons:
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
-                continue
-            _add_px(src_idx, d.bbox.x1, d.bbox.y1, d.bbox.x2, d.bbox.y2, "black", "KEY_ICON")
-
-    src_pdf.close()
     return [{"page_index": pi, "rects": rects} for pi, rects in sorted(result.items())]
 
 
@@ -517,94 +515,91 @@ def _split_from_redacted(
     opinion ending on that page uses the first number.
     """
     pages_by_index = {p.index: p for p in document.pages}
-    redacted = fitz.open(str(redacted_pdf_path))
+    with fitz.open(str(redacted_pdf_path)) as redacted:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = []
+        total = len(opinions)
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-    paths = []
-    total = len(opinions)
+        # Each opinion runs from its caption page to its key page.
+        page_ranges: list[tuple[int, int]] = []
+        for idx, (caption, key) in enumerate(opinions):
+            page_ranges.append((caption.page_index, key.page_index))
 
-    # Each opinion runs from its caption page to its key page.
-    page_ranges: list[tuple[int, int]] = []
-    for idx, (caption, key) in enumerate(opinions):
-        page_ranges.append((caption.page_index, key.page_index))
+        # Pre-compute base names using actual page numbers
+        from collections import Counter as _Counter
 
-    # Pre-compute base names using actual page numbers
-    from collections import Counter as _Counter
+        _reporter = document.reporter or ""
+        _volume = document.volume or ""
+        _bases: list[str] = []
+        for idx, (caption, _key) in enumerate(opinions):
+            start_idx, end_idx = page_ranges[idx]
+            first_num, last_num = _opinion_page_bounds(
+                pages_by_index.get(start_idx),
+                pages_by_index.get(end_idx),
+                start_idx,
+                end_idx,
+                first_page,
+            )
+            _bases.append(f"{_reporter}.{_volume}.{first_num:04d}-{last_num:04d}")
 
-    _reporter = document.reporter or ""
-    _volume = document.volume or ""
-    _bases: list[str] = []
-    for idx, (caption, _key) in enumerate(opinions):
-        start_idx, end_idx = page_ranges[idx]
-        first_num, last_num = _opinion_page_bounds(
-            pages_by_index.get(start_idx),
-            pages_by_index.get(end_idx),
-            start_idx,
-            end_idx,
-            first_page,
-        )
-        _bases.append(f"{_reporter}.{_volume}.{first_num:04d}-{last_num:04d}")
+        _name_counts = _Counter(_bases)
+        _name_seq: dict[str, int] = {}
 
-    _name_counts = _Counter(_bases)
-    _name_seq: dict[str, int] = {}
+        for idx, (caption, key) in enumerate(opinions):
+            start_idx, end_idx = page_ranges[idx]
+            with fitz.open() as out_pdf:
+                out_pdf.insert_pdf(redacted, from_page=start_idx, to_page=end_idx)
 
-    for idx, (caption, key) in enumerate(opinions):
-        start_idx, end_idx = page_ranges[idx]
-        out_pdf = fitz.open()
-        out_pdf.insert_pdf(redacted, from_page=start_idx, to_page=end_idx)
+                # Apply outside-opinion whiteout on first/last pages
+                for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
+                    if src_idx not in pages_by_index:
+                        continue
+                    page = pages_by_index[src_idx]
+                    fitz_page = out_pdf[local_idx]
+                    is_first = src_idx == start_idx
+                    is_last = src_idx == end_idx
 
-        # Apply outside-opinion whiteout on first/last pages
-        for local_idx, src_idx in enumerate(range(start_idx, end_idx + 1)):
-            if src_idx not in pages_by_index:
-                continue
-            page = pages_by_index[src_idx]
-            fitz_page = out_pdf[local_idx]
-            is_first = src_idx == start_idx
-            is_last = src_idx == end_idx
+                    if is_first or is_last:
+                        outside_rects = list(
+                            _outside_opinion_rects(
+                                page, fitz_page.rect.width, caption, key, is_first, is_last
+                            )
+                        )
+                        for rect in outside_rects:
+                            fitz_page.add_redact_annot(rect, fill=(1, 1, 1))
 
-            if is_first or is_last:
-                outside_rects = list(
-                    _outside_opinion_rects(
-                        page, fitz_page.rect.width, caption, key, is_first, is_last
-                    )
-                )
-                for rect in outside_rects:
-                    fitz_page.add_redact_annot(rect, fill=(1, 1, 1))
+                        # Bitonal-safe redaction
+                        _sample = fitz_page.get_images(full=True) if out_pdf.page_count else []
+                        _is_bit = bool(_sample and _sample[0][4] == 1)
+                        if _is_bit:
+                            white_rects = [(rect, (1, 1, 1)) for rect in outside_rects]
+                            if white_rects:
+                                _redact_bitonal_image(fitz_page, out_pdf, white_rects)
+                                fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+                            else:
+                                fitz_page.apply_redactions()
+                        else:
+                            fitz_page.apply_redactions()
+                        # Overdraw with fill-only rects to cover 1pt stroke
+                        for rect in outside_rects:
+                            fitz_page.draw_rect(rect, fill=(1, 1, 1), color=None, width=0)
 
-                # Bitonal-safe redaction
-                _sample = fitz_page.get_images(full=True) if out_pdf.page_count else []
-                _is_bit = bool(_sample and _sample[0][4] == 1)
-                if _is_bit:
-                    white_rects = [(rect, (1, 1, 1)) for rect in outside_rects]
-                    if white_rects:
-                        _redact_bitonal_image(fitz_page, out_pdf, white_rects)
-                        fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
-                    else:
-                        fitz_page.apply_redactions()
+                # Build filename — use -1/-2/-3 suffix when multiple opinions share the same page range
+                base = _bases[idx]
+                if _name_counts[base] > 1:
+                    _name_seq[base] = _name_seq.get(base, 0) + 1
+                    name = f"{base}-{_name_seq[base]}.pdf"
                 else:
-                    fitz_page.apply_redactions()
-                # Overdraw with fill-only rects to cover 1pt stroke
-                for rect in outside_rects:
-                    fitz_page.draw_rect(rect, fill=(1, 1, 1), color=None, width=0)
+                    name = f"{base}.pdf"
+                out_path = output_dir / name
 
-        # Build filename — use -1/-2/-3 suffix when multiple opinions share the same page range
-        base = _bases[idx]
-        if _name_counts[base] > 1:
-            _name_seq[base] = _name_seq.get(base, 0) + 1
-            name = f"{base}-{_name_seq[base]}.pdf"
-        else:
-            name = f"{base}.pdf"
-        out_path = output_dir / name
+                out_pdf.save(str(out_path), garbage=4, deflate=True)
+            paths.append(out_path)
 
-        out_pdf.save(str(out_path), garbage=4, deflate=True)
-        out_pdf.close()
-        paths.append(out_path)
+            done = idx + 1
+            if done % 20 == 0 or done == total:
+                print(f"    Split {done}/{total}", flush=True)
 
-        done = idx + 1
-        if done % 20 == 0 or done == total:
-            print(f"    Split {done}/{total}", flush=True)
-
-    redacted.close()
     print(f"  Wrote {len(paths)} redacted PDFs", flush=True)
     return paths
 
@@ -626,54 +621,51 @@ def _build_redacted_from_rects(
     for entry in rects_data:
         rects_by_page[entry["page_index"]] = entry["rects"]
 
-    src_pdf = fitz.open(str(document.pdf_path))
-    out_pdf = fitz.open()
-    out_pdf.insert_pdf(src_pdf)
+    with fitz.open(str(document.pdf_path)) as src_pdf, fitz.open() as out_pdf:
+        out_pdf.insert_pdf(src_pdf)
 
-    # Detect bitonal
-    _sample_imgs = out_pdf[0].get_images(full=True) if out_pdf.page_count else []
-    is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
+        # Detect bitonal
+        _sample_imgs = out_pdf[0].get_images(full=True) if out_pdf.page_count else []
+        is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
 
-    total_pages = len(document.pages)
-    pages_by_idx = {p.index: p for p in document.pages}
-    for page in document.pages:
-        src_idx = page.index
-        fitz_page = out_pdf[src_idx]
-        page_rects = rects_by_page.get(src_idx, [])
+        total_pages = len(document.pages)
+        pages_by_idx = {p.index: p for p in document.pages}
+        for page in document.pages:
+            src_idx = page.index
+            fitz_page = out_pdf[src_idx]
+            page_rects = rects_by_page.get(src_idx, [])
 
-        # Convert image pixel coords → PDF points
-        p = pages_by_idx.get(src_idx)
-        if p and p.img_width > 1:
-            to_pdf_x = p.pdf_width / p.img_width
-            to_pdf_y = p.pdf_height / p.img_height
-        else:
-            to_pdf_x = to_pdf_y = 1.0
+            # Convert image pixel coords → PDF points
+            p = pages_by_idx.get(src_idx)
+            if p and p.img_width > 1:
+                to_pdf_x = p.pdf_width / p.img_width
+                to_pdf_y = p.pdf_height / p.img_height
+            else:
+                to_pdf_x = to_pdf_y = 1.0
 
-        page_redact_rects = []
-        for r in page_rects:
-            rect = fitz.Rect(
-                r["x0"] * to_pdf_x, r["y0"] * to_pdf_y, r["x1"] * to_pdf_x, r["y1"] * to_pdf_y
-            )
-            if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
-                continue
-            fill_tuple = (0, 0, 0) if r.get("fill") == "black" else (1, 1, 1)
-            page_redact_rects.append((fitz.Rect(rect), fill_tuple))
-            fitz_page.add_redact_annot(rect, fill=fill_tuple)
+            page_redact_rects = []
+            for r in page_rects:
+                rect = fitz.Rect(
+                    r["x0"] * to_pdf_x, r["y0"] * to_pdf_y, r["x1"] * to_pdf_x, r["y1"] * to_pdf_y
+                )
+                if rect.is_empty or rect.y0 >= rect.y1 or rect.x0 >= rect.x1:
+                    continue
+                fill_tuple = (0, 0, 0) if r.get("fill") == "black" else (1, 1, 1)
+                page_redact_rects.append((fitz.Rect(rect), fill_tuple))
+                fitz_page.add_redact_annot(rect, fill=fill_tuple)
 
-        if is_bitonal and page_redact_rects:
-            _redact_bitonal_image(fitz_page, out_pdf, page_redact_rects)
-            fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
-        else:
-            fitz_page.apply_redactions()
+            if is_bitonal and page_redact_rects:
+                _redact_bitonal_image(fitz_page, out_pdf, page_redact_rects)
+                fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+            else:
+                fitz_page.apply_redactions()
 
-        pg = page.index + 1
-        if pg % 20 == 0 or pg == total_pages:
-            print(f"    Redacted {pg}/{total_pages} pages", flush=True)
+            pg = page.index + 1
+            if pg % 20 == 0 or pg == total_pages:
+                print(f"    Redacted {pg}/{total_pages} pages", flush=True)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    out_pdf.save(str(output_path), garbage=4, deflate=True)
-    out_pdf.close()
-    src_pdf.close()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        out_pdf.save(str(output_path), garbage=4, deflate=True)
 
     size_mb = output_path.stat().st_size / (1024 * 1024)
     print(f"  Saved {output_path.name} ({size_mb:.1f} MB)")
@@ -694,143 +686,140 @@ def _build_full_redacted(
     pages_by_index = {p.index: p for p in document.pages}
     mid = document.pages[0].midpoint
 
-    src_pdf = fitz.open(str(document.pdf_path))
-    out_pdf = fitz.open()
-    out_pdf.insert_pdf(src_pdf)
+    with fitz.open(str(document.pdf_path)) as src_pdf, fitz.open() as out_pdf:
+        out_pdf.insert_pdf(src_pdf)
 
-    # Detect bitonal — need special redaction path to avoid CCITT corruption
-    _sample_imgs = out_pdf[0].get_images(full=True) if out_pdf.page_count else []
-    is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
+        # Detect bitonal — need special redaction path to avoid CCITT corruption
+        _sample_imgs = out_pdf[0].get_images(full=True) if out_pdf.page_count else []
+        is_bitonal = bool(_sample_imgs and _sample_imgs[0][4] == 1)
 
-    # Pre-compute headnote rects for every opinion
-    all_keys, all_dets = _sorted_detections(document, mid)
-    all_headnote_rects: list[tuple[int, fitz.Rect]] = []
-    for caption, key in opinions:
-        page = pages_by_index[caption.page_index]
-        opinion_dets = _detections_in_range(
-            all_keys, all_dets, caption.sort_key(mid), key.sort_key(mid)
-        )
-        end_marker = _find_redaction_end(
-            opinion_dets, caption, key, mid, reporter=document.reporter
-        )
-        if end_marker is not None:
-            start = _find_redaction_start(opinion_dets, caption, mid)
-            all_headnote_rects.extend(
-                _redaction_rects(
-                    caption,
-                    end_marker,
-                    pages_by_index,
-                    start_marker=start if start is not caption else None,
+        # Pre-compute headnote rects for every opinion
+        all_keys, all_dets = _sorted_detections(document, mid)
+        all_headnote_rects: list[tuple[int, fitz.Rect]] = []
+        for caption, key in opinions:
+            page = pages_by_index[caption.page_index]
+            opinion_dets = _detections_in_range(
+                all_keys, all_dets, caption.sort_key(mid), key.sort_key(mid)
+            )
+            end_marker = _find_redaction_end(
+                opinion_dets, caption, key, mid, reporter=document.reporter
+            )
+            if end_marker is not None:
+                start = _find_redaction_start(opinion_dets, caption, mid)
+                all_headnote_rects.extend(
+                    _redaction_rects(
+                        caption,
+                        end_marker,
+                        pages_by_index,
+                        start_marker=start if start is not caption else None,
+                    )
                 )
-            )
-        else:
-            all_headnote_rects.extend(
-                _headnote_fallback_rects(opinion_dets, caption, pages_by_index, mid)
-            )
+            else:
+                all_headnote_rects.extend(
+                    _headnote_fallback_rects(opinion_dets, caption, pages_by_index, mid)
+                )
 
-    # Refine block rects to line-level with docTR
-    all_headnote_rects = refine_headnote_rects(src_pdf, all_headnote_rects, pages_by_index)
+        # Refine block rects to line-level with docTR
+        all_headnote_rects = refine_headnote_rects(src_pdf, all_headnote_rects, pages_by_index)
 
-    # Process each page
-    total_pages = len(document.pages)
-    for page in document.pages:
-        src_idx = page.index
-        fitz_page = out_pdf[src_idx]
-        sx, sy = page.scale_x, page.scale_y
+        # Process each page
+        total_pages = len(document.pages)
+        for page in document.pages:
+            src_idx = page.index
+            fitz_page = out_pdf[src_idx]
+            sx, sy = page.scale_x, page.scale_y
 
-        # Collect page number rects — never redact these
-        pn_rects = _collect_page_number_rects(page, fitz_page, sx, sy)
+            # Collect page number rects — never redact these
+            pn_rects = _collect_page_number_rects(page, fitz_page, sx, sy)
 
-        # Collect caption rects — CASE_SEQUENCE must not overlap these
-        caption_rects = []
-        for d in page.detections:
-            if d.label == Label.CASE_CAPTION:
-                caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
+            # Collect caption rects — CASE_SEQUENCE must not overlap these
+            caption_rects = []
+            for d in page.detections:
+                if d.label == Label.CASE_CAPTION:
+                    caption_rects.append(d.bbox.to_fitz_pdf_rect(sx, sy))
 
-        page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
-        add_safe = _make_add_safe(fitz_page, pn_rects, collector=page_redact_rects)
+            page_redact_rects: list[tuple[fitz.Rect, tuple]] = []
+            add_safe = _make_add_safe(fitz_page, pn_rects, collector=page_redact_rects)
 
-        # Headnote blackout
-        header_bottom, footer_top = _margin_bounds(page)
-        for rect_page_idx, rect in all_headnote_rects:
-            if rect_page_idx != src_idx:
-                continue
-            # `_build_full_redacted` always runs on post-OCR PDFs so text bounds
-            # are reliable; match that by passing ocr_applied=False to get the
-            # text-tightening branch.
-            clipped = _clip_headnote_rect(
-                fitz_page, rect, header_bottom, footer_top, ocr_applied=False
-            )
-            if clipped is not None:
-                add_safe(clipped, (0, 0, 0))
+            # Headnote blackout
+            header_bottom, footer_top = _margin_bounds(page)
+            for rect_page_idx, rect in all_headnote_rects:
+                if rect_page_idx != src_idx:
+                    continue
+                # `_build_full_redacted` always runs on post-OCR PDFs so text bounds
+                # are reliable; match that by passing ocr_applied=False to get the
+                # text-tightening branch.
+                clipped = _clip_headnote_rect(
+                    fitz_page, rect, header_bottom, footer_top, ocr_applied=False
+                )
+                if clipped is not None:
+                    add_safe(clipped, (0, 0, 0))
 
-        # Per-detection redactions
-        for d in page.detections:
-            if d.label not in (_REDACT_WHITE | _REDACT_BLACK):
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
-                continue
-            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
-            _skip_tighten = d.label in (Label.HEADNOTE_BRACKET, Label.STATE_ABBREVIATION)
-            if not _skip_tighten:
-                tight = _tighten_to_text(fitz_page, rect, skip=False)
-                if tight is not None:
-                    rect = tight
-            fill = (0, 0, 0) if d.label in _REDACT_BLACK else (1, 1, 1)
-            add_safe(rect, fill)
+            # Per-detection redactions
+            for d in page.detections:
+                if d.label not in (_REDACT_WHITE | _REDACT_BLACK):
+                    continue
+                if _check_excluded(d, excluded):
+                    continue
+                if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
+                    continue
+                rect = d.bbox.to_fitz_pdf_rect(sx, sy)
+                _skip_tighten = d.label in (Label.HEADNOTE_BRACKET, Label.STATE_ABBREVIATION)
+                if not _skip_tighten:
+                    tight = _tighten_to_text(fitz_page, rect, skip=False)
+                    if tight is not None:
+                        rect = tight
+                fill = (0, 0, 0) if d.label in _REDACT_BLACK else (1, 1, 1)
+                add_safe(rect, fill)
 
-        # CASE_SEQUENCE: redact black, but never overlap CASE_CAPTION
-        for rect in _iter_case_sequence_rects(page, sx, sy, caption_rects, excluded):
-            add_safe(rect, (0, 0, 0))
+            # CASE_SEQUENCE: redact black, but never overlap CASE_CAPTION
+            for rect in _iter_case_sequence_rects(page, sx, sy, caption_rects, excluded):
+                add_safe(rect, (0, 0, 0))
 
-        # Key icon redactions (always black, ratio-filtered only)
-        valid_key_icons = {
-            id(d)
-            for d in _filter_key_icons_by_size(
-                [x for x in page.detections if x.label == Label.KEY_ICON]
-            )
-        }
-        for d in page.detections:
-            if d.label != Label.KEY_ICON:
-                continue
-            if id(d) not in valid_key_icons:
-                continue
-            if _check_excluded(d, excluded):
-                continue
-            if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
-                continue
-            rect = d.bbox.to_fitz_pdf_rect(sx, sy)
-            add_safe(rect, (0, 0, 0))
+            # Key icon redactions (always black, ratio-filtered only)
+            valid_key_icons = {
+                id(d)
+                for d in _filter_key_icons_by_size(
+                    [x for x in page.detections if x.label == Label.KEY_ICON]
+                )
+            }
+            for d in page.detections:
+                if d.label != Label.KEY_ICON:
+                    continue
+                if id(d) not in valid_key_icons:
+                    continue
+                if _check_excluded(d, excluded):
+                    continue
+                if d.confidence < LABEL_CONFIDENCE.get(d.label, CONFIDENCE_THRESHOLD):
+                    continue
+                rect = d.bbox.to_fitz_pdf_rect(sx, sy)
+                add_safe(rect, (0, 0, 0))
 
-        if is_bitonal and page_redact_rects:
-            _redact_bitonal_image(fitz_page, out_pdf, page_redact_rects)
-            fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
-        else:
-            fitz_page.apply_redactions()
-        pg = page.index + 1
-        if pg % 20 == 0 or pg == total_pages:
-            print(f"    Redacted {pg}/{total_pages} pages", flush=True)
+            if is_bitonal and page_redact_rects:
+                _redact_bitonal_image(fitz_page, out_pdf, page_redact_rects)
+                fitz_page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+            else:
+                fitz_page.apply_redactions()
+            pg = page.index + 1
+            if pg % 20 == 0 or pg == total_pages:
+                print(f"    Redacted {pg}/{total_pages} pages", flush=True)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    out_pdf.save(str(output_path), garbage=4, deflate=True)
-    out_pdf.close()
-    src_pdf.close()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        out_pdf.save(str(output_path), garbage=4, deflate=True)
     size_mb = output_path.stat().st_size / (1024 * 1024)
     if size_mb > 50:
         # Skip recompression if already bitonal (1-bit images can't be compressed further)
-        reopen = fitz.open(str(output_path))
-        sample_imgs = reopen[0].get_images(full=True) if reopen.page_count else []
-        is_bitonal = bool(sample_imgs and sample_imgs[0][4] == 1)
-        if is_bitonal:
-            reopen.close()
-            print("  Skipping recompression (bitonal)")
-        else:
-            print(f"  Recompressing images ({size_mb:.1f} MB > 50 MB limit)...")
-            recompress_images(reopen)
-            data = reopen.tobytes(garbage=4, deflate=True)
-            reopen.close()
+        data = None
+        with fitz.open(str(output_path)) as reopen:
+            sample_imgs = reopen[0].get_images(full=True) if reopen.page_count else []
+            is_bitonal = bool(sample_imgs and sample_imgs[0][4] == 1)
+            if is_bitonal:
+                print("  Skipping recompression (bitonal)")
+            else:
+                print(f"  Recompressing images ({size_mb:.1f} MB > 50 MB limit)...")
+                recompress_images(reopen)
+                data = reopen.tobytes(garbage=4, deflate=True)
+        if data is not None:
             output_path.write_bytes(data)
             size_mb = output_path.stat().st_size / (1024 * 1024)
     print(f"  Saved {output_path.name} ({size_mb:.1f} MB)")
@@ -843,42 +832,41 @@ def _extract_images(document, output_dir: Path) -> int:
     Returns the number of images extracted.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    src_pdf = fitz.open(str(document.pdf_path))
-    # 300 DPI: PDF points are 72 per inch, so scale factor = 300/72
-    mat = fitz.Matrix(300 / 72, 300 / 72)
-    count = 0
+    with fitz.open(str(document.pdf_path)) as src_pdf:
+        # 300 DPI: PDF points are 72 per inch, so scale factor = 300/72
+        mat = fitz.Matrix(300 / 72, 300 / 72)
+        count = 0
 
-    for page in document.pages:
-        sx, sy = page.scale_x, page.scale_y
-        fitz_page = src_pdf[page.index]
+        for page in document.pages:
+            sx, sy = page.scale_x, page.scale_y
+            fitz_page = src_pdf[page.index]
 
-        # Collect IMAGE detections above confidence threshold
-        images = [
-            d
-            for d in page.detections
-            if d.label == Label.IMAGE
-            and d.confidence >= LABEL_CONFIDENCE.get(Label.IMAGE, CONFIDENCE_THRESHOLD)
-        ]
-        if not images:
-            continue
+            # Collect IMAGE detections above confidence threshold
+            images = [
+                d
+                for d in page.detections
+                if d.label == Label.IMAGE
+                and d.confidence >= LABEL_CONFIDENCE.get(Label.IMAGE, CONFIDENCE_THRESHOLD)
+            ]
+            if not images:
+                continue
 
-        # Sort by reading order (top-to-bottom, left-to-right)
-        images.sort(key=lambda d: d.sort_key(page.midpoint))
+            # Sort by reading order (top-to-bottom, left-to-right)
+            images.sort(key=lambda d: d.sort_key(page.midpoint))
 
-        for seq, det in enumerate(images, start=1):
-            clip = det.bbox.to_fitz_pdf_rect(sx, sy)
-            pix = fitz_page.get_pixmap(matrix=mat, clip=clip)
+            for seq, det in enumerate(images, start=1):
+                clip = det.bbox.to_fitz_pdf_rect(sx, sy)
+                pix = fitz_page.get_pixmap(matrix=mat, clip=clip)
 
-            # Use detected page number, fall back to index + first_page
-            page_num = page.page_number
-            if page_num is None:
-                page_num = page.index + document.first_page
+                # Use detected page number, fall back to index + first_page
+                page_num = page.page_number
+                if page_num is None:
+                    page_num = page.index + document.first_page
 
-            fname = f"{page_num:04d}-{seq:03d}.png"
-            pix.save(str(output_dir / fname))
-            count += 1
+                fname = f"{page_num:04d}-{seq:03d}.png"
+                pix.save(str(output_dir / fname))
+                count += 1
 
-    src_pdf.close()
     return count
 
 
@@ -958,10 +946,9 @@ def cmd_process(args: argparse.Namespace) -> None:
     # ── Bitonal conversion ──
     if getattr(args, "bitonal", False):
         # Skip if already bitonal (BitsPerComponent == 1)
-        doc_check = fitz.open(str(args.pdf))
-        sample_imgs = doc_check[0].get_images(full=True) if doc_check.page_count else []
-        is_bitonal = bool(sample_imgs and sample_imgs[0][4] == 1)
-        doc_check.close()
+        with fitz.open(str(args.pdf)) as doc_check:
+            sample_imgs = doc_check[0].get_images(full=True) if doc_check.page_count else []
+            is_bitonal = bool(sample_imgs and sample_imgs[0][4] == 1)
         if is_bitonal:
             print("Source PDF is already bitonal, skipping conversion.", flush=True)
         else:
@@ -1078,38 +1065,37 @@ def cmd_process(args: argparse.Namespace) -> None:
 
             large_model = YOLO(str(large_model_path))
             mat = fitz.Matrix(DPI / 72, DPI / 72)
-            pdf_file = fitz.open(str(document.pdf_path))
-            added = 0
-            for pi in missing_sa:
-                pix = pdf_file[pi].get_pixmap(matrix=mat)
-                img = _PILImage.frombytes("RGB", (pix.width, pix.height), pix.samples)
-                results = large_model([img], conf=0.50, verbose=False)
-                for box in results[0].boxes:
-                    cls = int(box.cls[0].item())
-                    conf = float(box.conf[0].item())
-                    if cls == int(Label.STATE_ABBREVIATION) and conf >= 0.50:
-                        bbox = box.xyxy[0].tolist()
-                        det = Detection(
-                            bbox=BBox.from_xyxy(bbox),
-                            label=Label.STATE_ABBREVIATION,
-                            confidence=float(box.conf[0].item()),
-                            page_index=pi,
-                        )
-                        _pages_by_idx[pi].detections.append(det)
-                        detections_data.append(
-                            {
-                                "page_index": pi,
-                                "label": "STATE_ABBREVIATION",
-                                "label_id": int(Label.STATE_ABBREVIATION),
-                                "confidence": round(float(box.conf[0].item()), 3),
-                                "bbox": [round(v, 1) for v in bbox],
-                                "page_number": _pages_by_idx[pi].page_number,
-                                "img_width": pix.width,
-                                "img_height": pix.height,
-                            }
-                        )
-                        added += 1
-            pdf_file.close()
+            with fitz.open(str(document.pdf_path)) as pdf_file:
+                added = 0
+                for pi in missing_sa:
+                    pix = pdf_file[pi].get_pixmap(matrix=mat)
+                    img = _PILImage.frombytes("RGB", (pix.width, pix.height), pix.samples)
+                    results = large_model([img], conf=0.50, verbose=False)
+                    for box in results[0].boxes:
+                        cls = int(box.cls[0].item())
+                        conf = float(box.conf[0].item())
+                        if cls == int(Label.STATE_ABBREVIATION) and conf >= 0.50:
+                            bbox = box.xyxy[0].tolist()
+                            det = Detection(
+                                bbox=BBox.from_xyxy(bbox),
+                                label=Label.STATE_ABBREVIATION,
+                                confidence=float(box.conf[0].item()),
+                                page_index=pi,
+                            )
+                            _pages_by_idx[pi].detections.append(det)
+                            detections_data.append(
+                                {
+                                    "page_index": pi,
+                                    "label": "STATE_ABBREVIATION",
+                                    "label_id": int(Label.STATE_ABBREVIATION),
+                                    "confidence": round(float(box.conf[0].item()), 3),
+                                    "bbox": [round(v, 1) for v in bbox],
+                                    "page_number": _pages_by_idx[pi].page_number,
+                                    "img_width": pix.width,
+                                    "img_height": pix.height,
+                                }
+                            )
+                            added += 1
             if added:
                 with open(detections_path, "w") as _f:
                     _json.dump(detections_data, _f)
@@ -1298,34 +1284,30 @@ def reprocess_section(
     pdf_end = page_end - first_page
 
     # Extract section
-    src_pdf = fitz.open(str(ocr_pdf_path))
     section_path = Path(tempfile.mktemp(suffix=".pdf"))
-    section_pdf = fitz.open()
-    section_pdf.insert_pdf(src_pdf, from_page=pdf_start, to_page=pdf_end)
-    section_pdf.save(str(section_path))
-    section_pdf.close()
-    src_pdf.close()
+    with fitz.open(str(ocr_pdf_path)) as src_pdf, fitz.open() as section_pdf:
+        section_pdf.insert_pdf(src_pdf, from_page=pdf_start, to_page=pdf_end)
+        section_pdf.save(str(section_path))
 
     print(f"Reprocessing section: pages {page_start}-{page_end} ({pdf_end - pdf_start + 1} pages)")
 
     # Apply drawn redactions to section extract before YOLO (non-destructive to OCR PDF)
     if redactions:
-        sec = fitz.open(str(section_path))
-        applied = 0
-        for r in redactions:
-            # Convert absolute page_number to local section index
-            local_idx = r["page_number"] - first_page - pdf_start
-            if 0 <= local_idx < sec.page_count:
-                page = sec[local_idx]
-                rect = fitz.Rect(r["x"], r["y"], r["x"] + r["width"], r["y"] + r["height"])
-                fill_color = (1, 1, 1) if r.get("fill") == "white" else (0, 0, 0)
-                page.add_redact_annot(rect, fill=fill_color)
-                page.apply_redactions()
-                applied += 1
-        if applied:
-            sec.save(str(section_path), garbage=4, deflate=True)
-            print(f"  Applied {applied} redaction(s) to section extract")
-        sec.close()
+        with fitz.open(str(section_path)) as sec:
+            applied = 0
+            for r in redactions:
+                # Convert absolute page_number to local section index
+                local_idx = r["page_number"] - first_page - pdf_start
+                if 0 <= local_idx < sec.page_count:
+                    page = sec[local_idx]
+                    rect = fitz.Rect(r["x"], r["y"], r["x"] + r["width"], r["y"] + r["height"])
+                    fill_color = (1, 1, 1) if r.get("fill") == "white" else (0, 0, 0)
+                    page.add_redact_annot(rect, fill=fill_color)
+                    page.apply_redactions()
+                    applied += 1
+            if applied:
+                sec.save(str(section_path), garbage=4, deflate=True)
+                print(f"  Applied {applied} redaction(s) to section extract")
 
     # Scan section (no OCR needed — already has text layer)
     yolo_model = YOLO(str(model))
@@ -1472,12 +1454,11 @@ def rebuild_full_redacted_from_detections(
     raw = _json.loads(detections_json_path.read_text())
 
     # Get PDF page dimensions
-    src_pdf = fitz.open(str(ocr_pdf_path))
-    page_dims: dict[int, tuple[float, float]] = {}
-    for i in range(len(src_pdf)):
-        r = src_pdf.load_page(i).rect
-        page_dims[i] = (r.width, r.height)
-    src_pdf.close()
+    with fitz.open(str(ocr_pdf_path)) as src_pdf:
+        page_dims: dict[int, tuple[float, float]] = {}
+        for i in range(len(src_pdf)):
+            r = src_pdf.load_page(i).rect
+            page_dims[i] = (r.width, r.height)
 
     # Group detections by page_index
     pages_data = _group_detections_by_page(raw)
@@ -1561,12 +1542,11 @@ def generate_files(
     print(f"Loaded {len(raw)} detections from {det_path.name}", flush=True)
 
     # Reconstruct Document from detections
-    src_pdf = fitz.open(str(ocr_pdf))
-    page_dims = {}
-    for i in range(len(src_pdf)):
-        r = src_pdf.load_page(i).rect
-        page_dims[i] = (r.width, r.height)
-    src_pdf.close()
+    with fitz.open(str(ocr_pdf)) as src_pdf:
+        page_dims = {}
+        for i in range(len(src_pdf)):
+            r = src_pdf.load_page(i).rect
+            page_dims[i] = (r.width, r.height)
 
     pages_data = _group_detections_by_page(raw, include_page_number_end=True)
 


### PR DESCRIPTION
- Downstream freelawproject/scanning sees ~200 MB/min memory growth in prod web pods (OOMKilled at ~9.8 GB). Traced to blackletter functions that open a fitz.Document, do work that can raise, and call .close() only on the happy path — every exception leaks the open mmap-backed Document (tens of MB per leak on volume-sized PDFs).
- Converts all fitz.open(...) / .close() pairs in margins.py, api.py, and process.py to with fitz.open(...) as doc: so the Document closes regardless of how the body exits. No behavior change on the happy path.
- Covers ~20 sites including the two highest-frequency call paths (pair, compute_redaction_rects) and a two-doc bitonal-converter leak