### PR TITLE
fix(validate): only flag genuinely detected page numbers as duplicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+- Fix `validate()` flagging real numbered pages as duplicates when a PDF starts with unnumbered front matter: pages with no detected number fell back to a `logical = pdf_page` placeholder that collided with the real page numbers. Only genuinely detected single page numbers now participate in `page_map` duplicate detection (#53)
+
 ## Current
 
 0.0.12 (2026-05-29)

--- a/blackletter/validate.py
+++ b/blackletter/validate.py
@@ -337,9 +337,8 @@ def _build_issues(
         # duplicate detection. Front-matter / undetected / out-of-range pages
         # fall back to ``logical = pdf_page`` purely as a display placeholder;
         # that placeholder must not be treated as a real page number, otherwise
-        # unnumbered front matter (e.g. cover + TOC on PDF pages 1-13) would
-        # "steal" logical numbers 1-13 and flag the real opinion pages numbered
-        # 1-13 as duplicates.
+        # unnumbered front matter (cover, tables, etc.) would "steal" the low
+        # logical numbers and flag the real numbered pages as duplicates.
         detected_single = False
         if r["pdf_page"] in out_of_range_pages:
             logical = r["pdf_page"]

--- a/blackletter/validate.py
+++ b/blackletter/validate.py
@@ -333,11 +333,20 @@ def _build_issues(
 
     for r in analysis["results"]:
         pdf_idx = r["pdf_page"] - 1
+        # Only pages with a genuinely detected page number participate in
+        # duplicate detection. Front-matter / undetected / out-of-range pages
+        # fall back to ``logical = pdf_page`` purely as a display placeholder;
+        # that placeholder must not be treated as a real page number, otherwise
+        # unnumbered front matter (e.g. cover + TOC on PDF pages 1-13) would
+        # "steal" logical numbers 1-13 and flag the real opinion pages numbered
+        # 1-13 as duplicates.
+        detected_single = False
         if r["pdf_page"] in out_of_range_pages:
             logical = r["pdf_page"]
         elif r["detected"] and r["type"] == "single":
             try:
                 logical = int(r["detected"])
+                detected_single = True
             except ValueError:
                 logical = r["pdf_page"]
         elif r["detected"] and r["type"] == "range":
@@ -354,15 +363,15 @@ def _build_issues(
         else:
             logical = r["pdf_page"]
 
-        is_dupe = logical in seen_logical
         entry: dict = {
             "type": "pdf_page",
             "pdf_index": pdf_idx,
             "logical_number": logical,
         }
-        if is_dupe:
-            entry["duplicate"] = True
-        seen_logical[logical] = pdf_idx
+        if detected_single:
+            if logical in seen_logical:
+                entry["duplicate"] = True
+            seen_logical[logical] = pdf_idx
         page_map.append(entry)
 
     # Insert missing page placeholders

--- a/tests/test_validate_page_map.py
+++ b/tests/test_validate_page_map.py
@@ -1,0 +1,69 @@
+"""Regression tests for page_map duplicate detection in validate._build_issues.
+
+Guards issue #90: unnumbered front matter (cover, table of contents) must not
+"steal" logical page numbers and flag the real, numbered pages as duplicates.
+"""
+
+from blackletter.validate import _build_issues
+
+
+def _analysis(results, duplicates=None, seen_nums=None):
+    """Build a minimal analysis dict for _build_issues from OCR results.
+
+    :param results: List of per-page OCR result dicts.
+    :param duplicates: Optional coverage-duplicates mapping.
+    :param seen_nums: Optional detected-number to pdf-pages mapping.
+    :returns: Analysis dict accepted by ``_build_issues``.
+    :rtype: dict
+    """
+    return {
+        "results": results,
+        "seq_issues": [],
+        "duplicates": duplicates or {},
+        "seen_nums": seen_nums or {},
+        "all_nums": sorted(seen_nums or {}),
+        "missing_pages": [],
+        "ranges_found": [],
+        "not_detected": [r for r in results if not r["detected"]],
+        "out_of_range": [],
+    }
+
+
+class TestPageMapDuplicates:
+    def test_front_matter_does_not_flag_real_pages_as_duplicate(self):
+        # PDF pages 1-3 are unnumbered front matter; pages 4-6 are the real
+        # opinion pages numbered 1-3. The front matter must not steal 1-3.
+        results = [
+            {"pdf_page": 1, "detected": None, "type": None},
+            {"pdf_page": 2, "detected": None, "type": None},
+            {"pdf_page": 3, "detected": None, "type": None},
+            {"pdf_page": 4, "detected": "1", "type": "single"},
+            {"pdf_page": 5, "detected": "2", "type": "single"},
+            {"pdf_page": 6, "detected": "3", "type": "single"},
+        ]
+        analysis = _analysis(results, seen_nums={1: [4], 2: [5], 3: [6]})
+
+        page_map = _build_issues(analysis, 6, 1, 3)["page_map"]
+
+        flagged = [e["pdf_index"] for e in page_map if e.get("duplicate")]
+        assert flagged == []
+
+    def test_genuine_duplicate_is_still_flagged(self):
+        # Two pages both genuinely read "2" -> the second is a real duplicate.
+        results = [
+            {"pdf_page": 1, "detected": None, "type": None},
+            {"pdf_page": 2, "detected": "1", "type": "single"},
+            {"pdf_page": 3, "detected": "2", "type": "single"},
+            {"pdf_page": 4, "detected": "2", "type": "single"},
+            {"pdf_page": 5, "detected": "3", "type": "single"},
+        ]
+        analysis = _analysis(
+            results,
+            duplicates={2: [3, 4]},
+            seen_nums={1: [2], 2: [3, 4], 3: [5]},
+        )
+
+        page_map = _build_issues(analysis, 5, 1, 3)["page_map"]
+
+        flagged = [e["pdf_index"] for e in page_map if e.get("duplicate")]
+        assert flagged == [3]  # only the second "2", pdf_page 4 (index 3)

--- a/tests/test_validate_page_map.py
+++ b/tests/test_validate_page_map.py
@@ -1,7 +1,8 @@
 """Regression tests for page_map duplicate detection in validate._build_issues.
 
-Guards issue #90: unnumbered front matter (cover, table of contents) must not
-"steal" logical page numbers and flag the real, numbered pages as duplicates.
+Guards against unnumbered front matter (cover, table of contents) "stealing"
+logical page numbers and flagging the real, numbered pages as duplicates
+(#52; surfaced in the scanning portal, freelawproject/scanning#100).
 """
 
 from blackletter.validate import _build_issues


### PR DESCRIPTION
## Summary

The `page_map` from `validate()` marked real numbered pages as duplicates when a PDF began with unnumbered front matter (cover, "Cases Reported" tables, etc.). Pages with no detected number fell back to a placeholder (`logical = pdf_page`), so the front matter claimed numbers 1..N and collided with the real numbered pages later in the document.

## Changes

- Only genuinely detected single page numbers participate in `page_map` duplicate detection; placeholder fallbacks (undetected, out-of-range, and range pages) no longer enter the dedup set or receive a `duplicate` flag.
- Coverage-based duplicate issues and sequence issues are unchanged, so genuine duplicate page numbers are still reported.
- Added `tests/test_validate_page_map.py`: front matter produces no false duplicates, and a genuine duplicate is still flagged.

Closes #52
