### PR TITLE
fix(validate): flag every copy of a duplicated page number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+- Flag every copy of a repeated page number as `duplicate` in `page_map`, not just the 2nd and later copies, so per-page duplicate markers match the `duplicate_page` issue's page list. Missing-page placeholders still anchor on the first copy (#55)
+
 ## Current
 
 0.0.13 (2026-06-18)

--- a/blackletter/validate.py
+++ b/blackletter/validate.py
@@ -329,7 +329,14 @@ def _build_issues(
     # --- Build page map ---
     page_map: list[dict] = []
     out_of_range_pages = {r["pdf_page"] for r in analysis.get("out_of_range", [])}
-    seen_logical: dict[int, int] = {}
+    # Maps a logical number to the first page_map entry that claimed it, so a
+    # later repeat can back-flag that first entry too (every copy of a repeated
+    # number is marked ``duplicate``, matching the duplicate_page issue's page
+    # list). ``extra_copy_indices`` tracks only the 2nd-and-later copies, whose
+    # logical numbers are unreliable and so are skipped when anchoring missing
+    # page placeholders.
+    seen_logical: dict[int, dict] = {}
+    extra_copy_indices: set[int] = set()
 
     for r in analysis["results"]:
         pdf_idx = r["pdf_page"] - 1
@@ -370,7 +377,11 @@ def _build_issues(
         if detected_single:
             if logical in seen_logical:
                 entry["duplicate"] = True
-            seen_logical[logical] = pdf_idx
+                extra_copy_indices.add(pdf_idx)
+                # Back-flag the first occurrence so every copy is marked.
+                seen_logical[logical]["duplicate"] = True
+            else:
+                seen_logical[logical] = entry
         page_map.append(entry)
 
     # Insert missing page placeholders
@@ -379,7 +390,10 @@ def _build_issues(
         for gap_num in actually_missing:
             insert_pos = len(page_map)
             for i, entry in enumerate(page_map):
-                if entry["logical_number"] > gap_num and not entry.get("duplicate"):
+                if (
+                    entry["logical_number"] > gap_num
+                    and entry.get("pdf_index") not in extra_copy_indices
+                ):
                     insert_pos = i
                     break
             inserts.append((insert_pos, gap_num))

--- a/tests/test_validate_page_map.py
+++ b/tests/test_validate_page_map.py
@@ -3,6 +3,10 @@
 Guards against unnumbered front matter (cover, table of contents) "stealing"
 logical page numbers and flagging the real, numbered pages as duplicates
 (#52; surfaced in the scanning portal, freelawproject/scanning#100).
+
+Also covers #55: every copy of a repeated page number is flagged
+``duplicate`` (matching the duplicate_page issue's page list), while
+missing-page placeholders still anchor on the first copy.
 """
 
 from blackletter.validate import _build_issues
@@ -49,8 +53,9 @@ class TestPageMapDuplicates:
         flagged = [e["pdf_index"] for e in page_map if e.get("duplicate")]
         assert flagged == []
 
-    def test_genuine_duplicate_is_still_flagged(self):
-        # Two pages both genuinely read "2" -> the second is a real duplicate.
+    def test_all_copies_of_a_duplicate_are_flagged(self):
+        # Two pages both genuinely read "2"; every copy is flagged (not just
+        # the later one), matching the duplicate_page issue's page list (#55).
         results = [
             {"pdf_page": 1, "detected": None, "type": None},
             {"pdf_page": 2, "detected": "1", "type": "single"},
@@ -67,4 +72,33 @@ class TestPageMapDuplicates:
         page_map = _build_issues(analysis, 5, 1, 3)["page_map"]
 
         flagged = [e["pdf_index"] for e in page_map if e.get("duplicate")]
-        assert flagged == [3]  # only the second "2", pdf_page 4 (index 3)
+        assert flagged == [2, 3]  # both "2" pages: pdf_page 3 and 4
+
+    def test_missing_page_anchors_before_first_duplicate_copy(self):
+        # Page 3 is missing and page 4 is duplicated. The missing-3 placeholder
+        # must still land before the FIRST copy of "4" (the reliable anchor),
+        # even though every copy of "4" is now flagged duplicate (#55).
+        results = [
+            {"pdf_page": 1, "detected": "1", "type": "single"},
+            {"pdf_page": 2, "detected": "2", "type": "single"},
+            {"pdf_page": 3, "detected": "4", "type": "single"},
+            {"pdf_page": 4, "detected": "4", "type": "single"},
+        ]
+        analysis = _analysis(
+            results,
+            duplicates={4: [3, 4]},
+            seen_nums={1: [1], 2: [2], 4: [3, 4]},
+        )
+        analysis["missing_pages"] = [3]
+
+        page_map = _build_issues(analysis, 4, 1, 4)["page_map"]
+
+        flagged = [e["pdf_index"] for e in page_map if e.get("duplicate")]
+        assert flagged == [2, 3]  # both "4" copies flagged
+
+        # The missing-3 placeholder sits before the first "4" (pdf_index 2).
+        missing_pos = next(
+            i for i, e in enumerate(page_map) if e["type"] == "missing" and e["logical_number"] == 3
+        )
+        first_four_pos = next(i for i, e in enumerate(page_map) if e.get("pdf_index") == 2)
+        assert missing_pos == first_four_pos - 1


### PR DESCRIPTION
When a detected page number repeats, `_build_issues` flagged only the 2nd and later copies in the `page_map` (`entry["duplicate"] = True`), treating the first occurrence as the canonical "keeper". The `duplicate_page` issue, however, lists every page the number appears on (e.g. "Page number 1 found on PDF pages [3, 9, 18]"), so consumers that render per-page duplicate markers from `page_map.duplicate` (the scanning portal's process viewer) badged only the later copies while the issue referenced all of them.

Now every copy of a repeated number is flagged, so the per-page markers match the issue's page list. When a repeat is found, the first occurrence is back-flagged too.

The only logic that depended on the old "2nd+ copies only" semantics was missing-page placeholder positioning, which skips duplicates because their logical numbers are unreliable but still needs the first copy as a valid anchor. That now uses a separate `extra_copy_indices` set (the 2nd-and-later copies), so insertion behavior is unchanged: a missing page still anchors before the first copy of a duplicated number.

Verified the full suite passes, plus a new regression test confirming the missing-page anchor is preserved, and against real scan data the change flags both copies of each genuine duplicate group (previously only the later copy).

Closes #55
