### PR TITLE
Add optional progress_callback to api.ocr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The following changes are not yet released, but are code complete:
 
 - **Breaking (packaging):** split the heavy inference stack out of the base dependencies into optional extras. `ultralytics` + `python-doctr[torch]` + `huggingface_hub` now install via `blackletter[detect]`; `blackletter[analyze]` adds PaddleOCR on top of `detect` (the analyze pipeline runs YOLO too). The base install (`pip install blackletter`) keeps only pairing, redaction, margins, validation, and OCR, and switches to `opencv-python-headless`. Consumers that run detection locally must install `blackletter[detect]` (or `[analyze]`); those that offload detection can stay lean and call redaction helpers with `skip_doctr=True`. To keep every advertised install path importable: the CLI's top-level `ultralytics` import moved into `cmd_draw`, and `compute_rects` / `pair_and_compute_rects` now propagate `skip_doctr` so lean-base callers can compute rects from remote detections without `doctr`
 - Flag every copy of a repeated page number as `duplicate` in `page_map`, not just the 2nd and later copies, so per-page duplicate markers match the `duplicate_page` issue's page list. Missing-page placeholders still anchor on the first copy (#55)
+- Add an optional `progress_callback` to `api.ocr()` that reports `(pages_done, total_pages)` as Tesseract completes pages, so consumers can surface OCR progress without copying the whole function. Default behavior (no callback, no progress bar) is unchanged (#60)
 
 ## Current
 

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -142,6 +142,7 @@ def ocr(
     volume: str = "",
     first_page: int = 1,
     language: str = "eng",
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> Path:
     """OCR a PDF (add text layer via ocrmypdf/Tesseract).
 
@@ -151,6 +152,9 @@ def ocr(
     :param volume: Volume number for the output filename.
     :param first_page: First page number (used to build the output filename).
     :param language: Tesseract language code.
+    :param progress_callback: Optional callable invoked with
+        ``(pages_done, total_pages)`` as Tesseract completes pages. When
+        omitted the OCR runs with no progress bar (the default).
     :returns: Path to the OCR'd PDF.
     """
     from blackletter.ocr import _silence_ocr_loggers
@@ -170,6 +174,47 @@ def ocr(
 
     import ocrmypdf
 
+    # ocrmypdf only exposes per-page progress through its progress-bar
+    # plugin hook, so a callback requires enabling the bar and routing
+    # its updates to the caller.
+    plugin_manager = None
+    if progress_callback is not None:
+        from ocrmypdf import hookimpl
+        from ocrmypdf._plugin_manager import get_plugin_manager
+
+        class _CallbackProgressBar:
+            def __init__(self, *, total=None, unit=None, **kwargs):
+                self._total = total or total_pages
+                self._unit = unit
+                self._current = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def update(self, n=1, *, completed=None):
+                # ocrmypdf drives several progress bars; only the
+                # page-unit ones track pages (the OCR pass, then the
+                # optimize pass — each a fresh bar instance, so the count
+                # restarts at zero per phase).
+                if self._unit != "page":
+                    return
+                self._current += n
+                # The optimize pass reports fractional steps; report a
+                # clean integer page count clamped to the total.
+                done = min(int(self._current), self._total)
+                progress_callback(done, self._total)
+
+        class _CallbackProgressPlugin:
+            @hookimpl
+            def get_progressbar_class(self):
+                return _CallbackProgressBar
+
+        plugin_manager = get_plugin_manager()
+        plugin_manager._pm.register(_CallbackProgressPlugin())
+
     print(f"  OCR {total_pages} pages...", flush=True)
     t0 = time.time()
     ocrmypdf.ocr(
@@ -180,7 +225,8 @@ def ocr(
         output_type="pdf",
         language=[language],
         tesseract_timeout=120,
-        progress_bar=False,
+        progress_bar=progress_callback is not None,
+        plugin_manager=plugin_manager,
     )
     print(f"  OCR done ({time.time() - t0:.0f}s)", flush=True)
     return output_path

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -183,9 +183,9 @@ def ocr(
         from ocrmypdf._plugin_manager import get_plugin_manager
 
         class _CallbackProgressBar:
-            def __init__(self, *, total=None, unit=None, **kwargs):
+            def __init__(self, *, total=None, desc=None, unit=None, **kwargs):
                 self._total = total or total_pages
-                self._unit = unit
+                self._desc = desc
                 self._current = 0
 
             def __enter__(self):
@@ -195,15 +195,18 @@ def ocr(
                 return False
 
             def update(self, n=1, *, completed=None):
-                # ocrmypdf drives several progress bars; only the
-                # page-unit ones track pages (the OCR pass, then the
-                # optimize pass — each a fresh bar instance, so the count
-                # restarts at zero per phase).
-                if self._unit != "page":
+                # ocrmypdf builds a fresh progress bar per phase. Several
+                # use unit="page" (the pdfinfo "Scanning contents" scan
+                # that runs *before* OCR, and the OCR pass itself), so
+                # matching on unit alone would report the pre-OCR scan
+                # filling to 100% and then reset to 0% for OCR. Track only
+                # the "OCR" bar to keep the reported count monotonic.
+                if self._desc != "OCR":
                     return
-                self._current += n
-                # The optimize pass reports fractional steps; report a
+                # The OCR pass calls update(0.5) twice per page
+                # (ocrmypdf/_pipelines/ocr.py), so accumulate and report a
                 # clean integer page count clamped to the total.
+                self._current += n
                 done = min(int(self._current), self._total)
                 progress_callback(done, self._total)
 


### PR DESCRIPTION
## Summary

`ocrmypdf` only exposes per-page OCR progress through its progress-bar plugin hook. Until now, any caller that wanted progress reporting (e.g. the [scanning](https://github.com/freelawproject/scanning) service) had to **copy the entire `ocr()` function** just to register that plugin. This adds an optional `progress_callback` to `api.ocr` so callers get progress without duplicating the function.

## What changed

- `api.ocr()` gains `progress_callback: Callable[[int, int], None] | None = None`.
- When provided, `ocr()` registers an ocrmypdf progress-bar plugin and calls the callback with `(pages_done, total_pages)` as pages complete.
- Reported counts are coerced to clean, clamped integers — ocrmypdf drives two `unit="page"` phases (OCR, then the optimize pass, which reports in fractional `0.5` steps).

## Backwards compatibility

Fully back-compatible. With no `progress_callback`, the progress bar stays off and `plugin_manager` defaults to `None` — byte-for-byte the previous behavior.

## Testing

Verified end-to-end against a real image-only PDF with Tesseract:
- **With** a callback: fires `1/3 → 2/3 → 3/3` during OCR, clamped integers during the optimize phase.
- **Without** a callback: unchanged, still produces the OCR'd PDF.

## Follow-up: scanning project

The scanning project currently keeps a copied `_ocr` in `services.py` **solely** to add this progress support. Once this lands, that copy should be deleted and `services._run_ocr` should call `blackletter.api.ocr(..., progress_callback=...)` directly.

## Version bump / release notes

New public API param → ship in the next release:
1. Bump `version` in `pyproject.toml`: `0.0.13 → 0.0.14`.
2. Publish `0.0.14` to PyPI.
3. In scanning (`pyproject.toml`): merge the companion change, bump the `blackletter` specifiers to `>=0.0.14`, and drop the temporary `[tool.uv.sources]` git pin to `split-heavy-deps-into-extras` — exactly the TODO already noted there.
