### PR TITLE
Move python-doctr[torch] into an optional [refine] extra

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+- **Breaking (packaging):** move `python-doctr[torch]` out of the `detect` extra into a new `refine` extra, so `blackletter[detect]` / `blackletter[analyze]` no longer install docTR (~200 MB of dependencies). docTR is only used by the line-level headnote-refinement pass in `refine.py`; consumers that call redaction with `skip_doctr=True` (e.g. the scanning web/daemon image) never invoke it. Installs that run refinement — including the `process` CLI command — must now add `[refine]` (e.g. `blackletter[analyze,refine]`). With docTR missing, the refinement pass raises a clear `ImportError` pointing at `pip install blackletter[refine]` / `skip_doctr=True` (#64)
+
 ## Current
 
 0.1.0 (2026-07-10)

--- a/README.md
+++ b/README.md
@@ -19,19 +19,21 @@ detection (e.g. to a remote GPU worker) can keep a lean install:
 | Install | Adds | Use for |
 |---|---|---|
 | `blackletter` | base pipeline: pairing, redaction, margins, validation, OCR | pairing/redaction when detection is offloaded (pass `skip_doctr=True`) |
-| `blackletter[detect]` | local YOLO detection (ultralytics + torch, doctr, huggingface_hub) | running `detect()` and the `process` / `draw` CLI locally |
+| `blackletter[detect]` | local YOLO detection (ultralytics + torch, huggingface_hub) | running `detect()` and the `draw` CLI locally |
+| `blackletter[refine]` | docTR line-level headnote refinement | redaction without `skip_doctr=True`; the `process` CLI |
 | `blackletter[analyze]` | the analyze pipeline: PaddleOCR (paddlepaddle, paddleocr) **plus** `detect` | `analyze_pdf()` / page-number validation |
-| `blackletter[detect,analyze]` | same as `[analyze]` | the full local pipeline |
+| `blackletter[analyze,refine]` | everything above | the full local pipeline |
 
 Notes:
 - `[analyze]` includes `[detect]` — the analyze pipeline runs YOLO in addition to PaddleOCR.
-- On the base install, docTR headnote refinement is unavailable, so redaction helpers must be called with `skip_doctr=True`; the `process` and `draw` CLI commands run YOLO and require `[detect]`.
+- Without `[refine]`, docTR headnote refinement is unavailable, so redaction helpers must be called with `skip_doctr=True`. `[refine]` is kept separate from `[detect]`/`[analyze]` so consumers that skip refinement (e.g. a web/daemon image) save ~200 MB of dependencies.
+- The `process` and `draw` CLI commands run YOLO and require `[detect]`; `process` also runs the refinement pass and requires `[refine]`.
 
 Or install from source:
 ```bash
 git clone https://github.com/freelawproject/blackletter
 cd blackletter
-pip install -e '.[detect,analyze]'
+pip install -e '.[analyze,refine]'
 ```
 
 ## Quick Start

--- a/blackletter/api.py
+++ b/blackletter/api.py
@@ -513,8 +513,8 @@ def compute_rects(
     :param output_dir: Directory containing detections.json.
     :param excluded: Set of page indices to exclude from pairing.
     :param approved: Set of page indices pre-approved for redaction.
-    :param skip_doctr: Skip the docTR headnote-refinement pass. Set True on a
-        lean base install (no ``detect`` extra) to avoid importing ``doctr``.
+    :param skip_doctr: Skip the docTR headnote-refinement pass. Set True on an
+        install without the ``refine`` extra to avoid importing ``doctr``.
     :returns: List of redaction rect dicts.
     """
     from blackletter.tasks import pair_and_compute_rects as _pair_compute

--- a/blackletter/refine.py
+++ b/blackletter/refine.py
@@ -16,7 +16,15 @@ _SCALE = DPI / 72  # PDF points → pixels
 def _get_doctr_model():
     """Lazy-load docTR detection model (singleton)."""
     if not hasattr(_get_doctr_model, "_model"):
-        from doctr.models import detection_predictor
+        try:
+            from doctr.models import detection_predictor
+        except ImportError as e:
+            raise ImportError(
+                "python-doctr is required for line-level headnote refinement "
+                "but is not installed. Install it with "
+                "`pip install blackletter[refine]`, or pass skip_doctr=True "
+                "to skip the refinement pass."
+            ) from e
 
         _get_doctr_model._model = detection_predictor(arch="db_resnet50", pretrained=True)
     return _get_doctr_model._model

--- a/blackletter/tasks.py
+++ b/blackletter/tasks.py
@@ -356,8 +356,8 @@ def pair_and_compute_rects(
     runs pairing, computes rects with docTR, saves results.
 
     Set ``skip_doctr=True`` to skip the docTR headnote-refinement pass,
-    which avoids importing ``doctr`` (only available via the ``detect``
-    extra) — required when computing rects on a lean base install.
+    which avoids importing ``doctr`` (only available via the ``refine``
+    extra) — required when computing rects without that extra installed.
 
     Returns:
         Dict with opinions_count, rects_count.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,10 @@ classifiers = [
 # Heavy detection/OCR frameworks live in the `detect` / `analyze` extras so a
 # consumer that offloads inference (e.g. to RunPod) can install a lean tree.
 # cv2 is the only heavy top-level import in the base modules (scanner.py). Base
-# uses the non-headless `opencv-python` on purpose: the `detect`/`analyze`
-# extras pull `opencv-python` transitively (via ultralytics and python-doctr),
-# and both cv2 distributions own the same top-level `cv2` package, so declaring
+# uses the non-headless `opencv-python` on purpose: the `detect`/`analyze`/
+# `refine` extras pull `opencv-python` transitively (via ultralytics and
+# python-doctr), and both cv2 distributions own the same top-level `cv2`
+# package, so declaring
 # `opencv-python-headless` here would double-install a conflicting cv2 whenever
 # an extra is present. Base callers that never touch cv2 pay only libgl1.
 dependencies = [
@@ -44,12 +45,18 @@ dev = [
     "ruff>=0.1.0",
 ]
 # Local YOLO detection (torch-backed). Also required by the CLI `process`/`draw`
-# commands and by refine.py's doctr headnote model. huggingface_hub downloads
-# the on-demand `large.pt` weight. Not needed when detection is offloaded.
+# commands. huggingface_hub downloads the on-demand `large.pt` weight. Not
+# needed when detection is offloaded.
 detect = [
     "ultralytics>=8.0.0",
-    "python-doctr[torch]>=1.0.1",
     "huggingface_hub>=0.20.0",
+]
+# docTR line-level headnote refinement (refine.py). Kept out of `detect` /
+# `analyze` so consumers that call redaction with `skip_doctr=True` (e.g. the
+# web/daemon image) don't pay ~200 MB for a model they never invoke. The CLI
+# `process` command runs the refinement pass and needs this extra.
+refine = [
+    "python-doctr[torch]>=1.0.1",
 ]
 # The analyze pipeline (analyze_pdf / page-number validation) runs YOLO in
 # addition to PaddleOCR, so it builds on `detect`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,9 @@ classifiers = [
 
 # Base deps cover pairing, redaction (with skip_doctr=True), margins,
 # validation, OCR and PDF handling — everything that runs without a GPU model.
-# Heavy detection/OCR frameworks live in the `detect` / `analyze` extras so a
-# consumer that offloads inference (e.g. to RunPod) can install a lean tree.
+# Heavy detection/OCR frameworks live in the `detect` / `analyze` / `refine`
+# extras so a consumer that offloads inference (e.g. to RunPod) can install a
+# lean tree.
 # cv2 is the only heavy top-level import in the base modules (scanner.py). Base
 # uses the non-headless `opencv-python` on purpose: the `detect`/`analyze`/
 # `refine` extras pull `opencv-python` transitively (via ultralytics and

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -107,3 +107,45 @@ class TestLazyUltralyticsImport:
             """
         )
         assert out == "AttributeError"
+
+
+class TestLazyDoctrImport:
+    """docTR lives in the optional ``refine`` extra; importing blackletter
+    modules must not load it, and its absence must fail with a clear error."""
+
+    def test_import_refine_does_not_load_doctr(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.refine  # noqa: F401
+            print('doctr' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_import_process_does_not_load_doctr(self):
+        out = _run(
+            """
+            import sys
+            import blackletter.process  # noqa: F401
+            print('doctr' in sys.modules)
+            """
+        )
+        assert out == "False"
+
+    def test_missing_doctr_raises_helpful_import_error(self):
+        """Without the ``refine`` extra, the error must name the fix."""
+        out = _run(
+            """
+            import sys
+            sys.modules['doctr'] = None  # force ImportError even if installed
+            from blackletter.refine import _get_doctr_model
+            try:
+                _get_doctr_model()
+            except ImportError as exc:
+                assert 'blackletter[refine]' in str(exc), str(exc)
+                assert 'skip_doctr' in str(exc), str(exc)
+                print('ImportError')
+            """
+        )
+        assert out == "ImportError"

--- a/uv.lock
+++ b/uv.lock
@@ -88,11 +88,11 @@ wheels = [
 
 [[package]]
 name = "blackletter"
-version = "0.0.13"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "ocrmypdf" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
 ]
@@ -103,12 +103,10 @@ analyze = [
     { name = "paddleocr" },
     { name = "paddlepaddle" },
     { name = "pypdfium2" },
-    { name = "python-doctr" },
     { name = "ultralytics" },
 ]
 detect = [
     { name = "huggingface-hub" },
-    { name = "python-doctr" },
     { name = "ultralytics" },
 ]
 dev = [
@@ -116,13 +114,16 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+refine = [
+    { name = "python-doctr" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "blackletter", extras = ["detect"], marker = "extra == 'analyze'" },
     { name = "huggingface-hub", marker = "extra == 'detect'", specifier = ">=0.20.0" },
     { name = "ocrmypdf", specifier = ">=16.0.0" },
-    { name = "opencv-python-headless", specifier = ">=4.8.0" },
+    { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "paddleocr", marker = "extra == 'analyze'", specifier = ">=3.0.0" },
     { name = "paddlepaddle", marker = "extra == 'analyze'", specifier = ">=3.0.0" },
     { name = "pillow", specifier = ">=12.0.0" },
@@ -130,11 +131,11 @@ requires-dist = [
     { name = "pypdfium2", marker = "extra == 'analyze'", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "python-doctr", extras = ["torch"], marker = "extra == 'detect'", specifier = ">=1.0.1" },
+    { name = "python-doctr", extras = ["torch"], marker = "extra == 'refine'", specifier = ">=1.0.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "ultralytics", marker = "extra == 'detect'", specifier = ">=8.0.0" },
 ]
-provides-extras = ["dev", "detect", "analyze"]
+provides-extras = ["dev", "detect", "refine", "analyze"]
 
 [[package]]
 name = "certifi"
@@ -1465,25 +1466,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/8b/90eb44a40476fa0e71e05a0283947cfd74a5d36121a11d926ad6f3193cc4/opencv_python-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b02611523803495003bd87362db3e1d2a0454a6a63025dc6658a9830570aa0d", size = 62986597, upload-time = "2025-01-16T13:52:08.836Z" },
     { url = "https://files.pythonhosted.org/packages/fb/d7/1d5941a9dde095468b288d989ff6539dd69cd429dbf1b9e839013d21b6f0/opencv_python-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:810549cb2a4aedaa84ad9a1c92fbfdfc14090e2749cedf2c1589ad8359aa169b", size = 29384337, upload-time = "2025-01-16T13:52:13.549Z" },
     { url = "https://files.pythonhosted.org/packages/a4/7d/f1c30a92854540bf789e9cd5dde7ef49bbe63f855b85a2e6b3db8135c591/opencv_python-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:085ad9b77c18853ea66283e98affefe2de8cc4c1f43eda4c100cf9b2721142ec", size = 39488044, upload-time = "2025-01-16T13:52:21.928Z" },
-]
-
-[[package]]
-name = "opencv-python-headless"
-version = "5.0.0.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/7c/8c8097891c509d98cd128493835c95631c80be6a8f37ed9d25716c2e16f1/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:030ca5e0837a2963ab36ef896baa9767eb8d2b83353fb28af5a521e40dd8756f", size = 48322581, upload-time = "2026-07-02T05:50:34.207Z" },
-    { url = "https://files.pythonhosted.org/packages/90/8c/eab2ad388c3cbab2a350c10c2ef19ce6bd099240afc31789032c996bab52/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1e55af3abfb462eeeabe5c775f12bdb36216d8a93a3583d69e6bd6e1d6ba7d00", size = 34782894, upload-time = "2026-07-02T05:51:39.856Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/78/afca939f40ffe2b2380bfa86f812b2f7d4acc5a27b27dc41b49cad7ce7b4/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10818d91510e05c04568ae12b5cd120779c70c01bf897b001a6221fe430df80f", size = 36521085, upload-time = "2026-07-02T06:55:24.429Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/97/8170e9819764c47e436c130d3ff6cfb73b58f923eae9d3a03d8982b04aec/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09a872a157c1376ab922a69bbf22f9a95bcc7b658a9d8b436a60212b02b2eeb4", size = 56563598, upload-time = "2026-07-02T06:55:47.355Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/98/1a28a7101e31801042b3098871a74b76c61581d328ef40774ff4edb53a56/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:840bd717c21e5c11cadadc022a823315ea417f961213d06b4df010e019eb16f4", size = 39648433, upload-time = "2026-07-02T06:56:04.255Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed709fdf9aa0bd1f2ed8549e71d19449b03a675bb581eb292285f6861953be37", size = 61204038, upload-time = "2026-07-02T06:56:41.823Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/8f/b8756467ea991449a293797f6b3fa80fcfdd29598a0a60d1cd5715b96e61/opencv_python_headless-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:c6bcd96b185975ea240d22cfdb15a1f6d080cc95264cfbe2621f21bb144d89b9", size = 35411237, upload-time = "2026-07-02T05:50:12.901Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/88/763b967f7efd7226b82c9fae16d560cba049b1f0c036647e65c610fd636e/opencv_python_headless-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:829717b6a95554f273e49e357cee3b3a2a26b6f4842fbc1bed2b45bdd8f87e0e", size = 43825962, upload-time = "2026-07-02T05:50:09.627Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #64

## Motivation

docTR is only used by the line-level headnote-refinement pass in `refine.py`, but it shipped inside the `[detect]` extra, so every `[detect]`/`[analyze]` consumer paid ~200 MB of dependencies (scipy, onnx, ml_dtypes, h5py, …) for a model many never invoke. The scanning web/daemon image calls `compute_redaction_rects` with `skip_doctr=True`, and the RunPod worker never computes rects at all, so neither ever touches docTR.

## Changes

- **pyproject.toml**: drop `python-doctr[torch]` from `[detect]`; add a new `[refine]` extra holding it. `[analyze]` still builds on `[detect]` and no longer pulls docTR.
- **refine.py**: raise a clear `ImportError` naming the fix (`pip install blackletter[refine]`, or pass `skip_doctr=True`) when docTR is missing. The import was already lazy, so base imports are unaffected.
- **README / docstrings**: document the new extra. The `process` CLI command runs the refinement pass and now requires `[refine]` in addition to `[detect]`; the full local install is `blackletter[analyze,refine]`.
- **tests**: new `TestLazyDoctrImport` asserts that importing `blackletter.refine`/`blackletter.process` never loads doctr, and that the missing-doctr error names `blackletter[refine]` and `skip_doctr` (doctr is force-blocked via `sys.modules` so the test passes regardless of whether it's installed).
- **uv.lock**: re-locked; also picks up the stale 0.1.0 version bump from #63.

## Verification

- `pytest` with `[dev,detect]` (the CI matrix): 85 passed, 13 skipped — no existing test exercises the doctr path, so CI needs no workflow change.
- `uv run --extra dev --extra detect python -c 'import doctr'` → `ModuleNotFoundError` (doctr no longer reaches detect/analyze consumers).
- `uv run --extra refine python -c 'import doctr'` → doctr v1.0.1 installs and imports via the new extra.
- With doctr absent, `_get_doctr_model()` raises the new descriptive `ImportError`, and all blackletter modules still import cleanly.

## Follow-up (downstream)

Once this ships in a release, the scanning repo keeps `blackletter[analyze]` **without** `[refine]` on the web/daemon image for the ~200 MB image-size reduction (see freelawproject/blackletter#64 for measurements).