### PR TITLE
version bump v0.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,18 +4,20 @@
 
 The following changes are not yet released, but are code complete:
 
+## Current
+
+0.1.1 (2026-07-15)
+
 - **Breaking (packaging):** stop bundling `small.pt` and `medium.pt` in the package (~72 MB smaller wheel). All three YOLO weights are now downloaded on demand from [freelawproject/blackletter-weights](https://huggingface.co/freelawproject/blackletter-weights) via `ensure_weights`, the same way `large.pt` already was; `large.pt` moves from `flooie/blackletter-large` to the same consolidated repo. Downloads are pinned to a specific commit of the weights repo so a compromised repo can't serve different binaries. Downloading requires `huggingface_hub` (installed with `blackletter[detect]`) (#59)
 - **Breaking (packaging):** move `python-doctr[torch]` out of the `detect` extra into a new `refine` extra, so `blackletter[detect]` / `blackletter[analyze]` no longer install docTR (~200 MB of dependencies). docTR is only used by the line-level headnote-refinement pass in `refine.py`; consumers that call redaction with `skip_doctr=True` (e.g. the scanning web/daemon image) never invoke it. Installs that run refinement — including the `process` CLI command — must now add `[refine]` (e.g. `blackletter[analyze,refine]`). With docTR missing, the refinement pass raises a clear `ImportError` pointing at `pip install blackletter[refine]` / `skip_doctr=True` (#64)
 
-## Current
+## Past
 
 0.1.0 (2026-07-10)
 
 - **Breaking (packaging):** split the heavy inference stack out of the base dependencies into optional extras. `ultralytics` + `python-doctr[torch]` + `huggingface_hub` now install via `blackletter[detect]`; `blackletter[analyze]` adds PaddleOCR on top of `detect` (the analyze pipeline runs YOLO too). The base install (`pip install blackletter`) keeps only pairing, redaction, margins, validation, and OCR. Base stays on `opencv-python` (not `-headless`): the `detect`/`analyze` extras pull `opencv-python` transitively via ultralytics and python-doctr, and both cv2 distributions own the same top-level `cv2` package, so a headless base would double-install a conflicting cv2 whenever an extra is present (#61). Consumers that run detection locally must install `blackletter[detect]` (or `[analyze]`); those that offload detection can stay lean and call redaction helpers with `skip_doctr=True`. To keep every advertised install path importable: the CLI's top-level `ultralytics` import moved into `cmd_draw`, and `compute_rects` / `pair_and_compute_rects` now propagate `skip_doctr` so lean-base callers can compute rects from remote detections without `doctr`
 - Flag every copy of a repeated page number as `duplicate` in `page_map`, not just the 2nd and later copies, so per-page duplicate markers match the `duplicate_page` issue's page list. Missing-page placeholders still anchor on the first copy (#55)
 - Add an optional `progress_callback` to `api.ocr()` that reports `(pages_done, total_pages)` as Tesseract completes pages, so consumers can surface OCR progress without copying the whole function. Default behavior (no callback, no progress bar) is unchanged (#60)
-
-## Past
 
 0.0.13 (2026-06-18)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blackletter"
-version = "0.1.0"
+version = "0.1.1"
 description = "Remove copyrighted material from legal case law PDFs"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump version from 0.1.0 to 0.1.1.

- **Breaking (packaging):** stop bundling `small.pt` and `medium.pt` in the package (~72 MB smaller wheel). All three YOLO weights now download on demand from [freelawproject/blackletter-weights](https://huggingface.co/freelawproject/blackletter-weights) via `ensure_weights`, pinned to a specific commit of the weights repo (#59)
- **Breaking (packaging):** move `python-doctr[torch]` out of the `detect` extra into a new `refine` extra, so `blackletter[detect]` / `blackletter[analyze]` no longer install docTR (~200 MB). Installs that run refinement must add `[refine]` (#64)